### PR TITLE
Delete github.svg:Zone.Identifier

### DIFF
--- a/client/public/images/icons/github.svg:Zone.Identifier
+++ b/client/public/images/icons/github.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://fontawesome.com/


### PR DESCRIPTION
I removed `github.svg:Zone.Identifier` file, because I can't clone the repo on Windows OS (Windows use `:` for drive letters).
From my quick research, it just provides metadata for the image, to be able to tell where it originates (viewing file in github online file viewer confirms that).