### PR TITLE
Create and use npm run docker-start for the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ WORKDIR /app
 ENV NODE_ENV production
 ENV PATH /root/.volta/bin:$PATH
 
-CMD [ "npm", "run", "start" ]
+CMD [ "npm", "run", "docker-start" ]

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	},
 	"scripts": {
 		"start": "npm run server",
+		"docker-start": "npm run build && npm run start",
 		"server": "node --experimental-specifier-resolution=node server",
 		"server:inspect": "node --experimental-specifier-resolution=node --inspect server",
 		"dev": "vite client/",


### PR DESCRIPTION
When mounting in a custom server-config.json file, the client needs to be updated with the config updates. this is why we run a build before the start.
This slows down start times, but it's needed if we want to have custom configs work on the client.