### PR TITLE
Deckurl

### DIFF
--- a/client/src/app/deck/deck.tsx
+++ b/client/src/app/deck/deck.tsx
@@ -124,7 +124,9 @@ const Deck = ({setMenuSection}: Props) => {
 	const sortedDeckCards = sortCards(pickedCards)
 	const urlParams = new URLSearchParams(document.location.search || '')
 	if (urlParams.has('deck')) {
-		setShowImportExport(true)
+		setTimeout(() => {
+			setShowImportExport(true)
+		}, 750)
 	}
 
 	return (

--- a/client/src/app/deck/deck.tsx
+++ b/client/src/app/deck/deck.tsx
@@ -122,10 +122,10 @@ const Deck = ({setMenuSection}: Props) => {
 
 	const sortedAllCards = sortCards(allCards)
 	const sortedDeckCards = sortCards(pickedCards)
-	/*const urlParams = new URLSearchParams(document.location.search || "")
-        if (urlParams.has("deck")){
-            setShowImportExport(true);
-        }*/
+	const urlParams = new URLSearchParams(document.location.search || '')
+	if (urlParams.has('deck')) {
+		setShowImportExport(true)
+	}
 
 	return (
 		<div className={css.deck}>

--- a/client/src/app/deck/deck.tsx
+++ b/client/src/app/deck/deck.tsx
@@ -122,6 +122,10 @@ const Deck = ({setMenuSection}: Props) => {
 
 	const sortedAllCards = sortCards(allCards)
 	const sortedDeckCards = sortCards(pickedCards)
+	/*const urlParams = new URLSearchParams(document.location.search || "")
+        if (urlParams.has("deck")){
+            setShowImportExport(true);
+        }*/
 
 	return (
 		<div className={css.deck}>

--- a/client/src/app/deck/import-export/import-export.tsx
+++ b/client/src/app/deck/import-export/import-export.tsx
@@ -41,14 +41,15 @@ const ImportExport = ({pickedCards, setPickedCards, close}: Props) => {
 		inputRef.current.value = b64cards
 	}
 
-	/*const urlParams = new URLSearchParams(document.location.search || "")
-        if (urlParams.has("deck")){
-                const b64cards = urlParams.get("deck") || "";
-                window.history.replaceState({}, "", window.location.pathname);
-                if (!inputRef.current) return
-                inputRef.current.value = b64cards
-                importDeck()
-        }*/
+	const urlParams = new URLSearchParams(document.location.search || '')
+	if (urlParams.has('deck')) {
+		const b64cards = urlParams.get('deck') || ''
+		window.history.replaceState({}, '', window.location.pathname)
+		if (inputRef.current) {
+			inputRef.current.value = b64cards
+			importDeck()
+		}
+	}
 
 	return (
 		<Modal title="Import/Export" closeModal={close}>

--- a/client/src/app/deck/import-export/import-export.tsx
+++ b/client/src/app/deck/import-export/import-export.tsx
@@ -43,12 +43,16 @@ const ImportExport = ({pickedCards, setPickedCards, close}: Props) => {
 
 	const urlParams = new URLSearchParams(document.location.search || '')
 	if (urlParams.has('deck')) {
-		const b64cards = urlParams.get('deck') || ''
-		window.history.replaceState({}, '', window.location.pathname)
-		if (inputRef.current) {
-			inputRef.current.value = b64cards
-			importDeck()
-		}
+		setTimeout(() => {
+			const b64cards = urlParams.get('deck') || ''
+			window.history.replaceState({}, '', window.location.pathname)
+			if (!inputRef.current) {
+				console.log('should be set...')
+			} else {
+				inputRef.current.value = b64cards
+				importDeck()
+			}
+		}, 500)
 	}
 
 	return (

--- a/client/src/app/deck/import-export/import-export.tsx
+++ b/client/src/app/deck/import-export/import-export.tsx
@@ -41,6 +41,15 @@ const ImportExport = ({pickedCards, setPickedCards, close}: Props) => {
 		inputRef.current.value = b64cards
 	}
 
+	/*const urlParams = new URLSearchParams(document.location.search || "")
+        if (urlParams.has("deck")){
+                const b64cards = urlParams.get("deck") || "";
+                window.history.replaceState({}, "", window.location.pathname);
+                if (!inputRef.current) return
+                inputRef.current.value = b64cards
+                importDeck()
+        }*/
+
 	return (
 		<Modal title="Import/Export" closeModal={close}>
 			<div className={css.importExport}>

--- a/client/src/app/main-menu/main-menu.tsx
+++ b/client/src/app/main-menu/main-menu.tsx
@@ -24,8 +24,12 @@ function MainMenu({setMenuSection}: Props) {
 	const handleJoinPrivateGame = () => dispatch(joinPrivateGame())
 	const handleLogOut = () => dispatch(logout())
 	const handleDeck = () => setMenuSection('deck')
+	const urlParams = new URLSearchParams(document.location.search || '')
 
 	let content = null
+	if (urlParams.has('deck')) {
+		setMenuSection('deck')
+	}
 
 	if (subsection === 'more') {
 		content = <More setMenuSection={() => setSubsection(null)} />


### PR DESCRIPTION
This one introduces a deep link for decks: `https://tcg.prof.ninja/?deck=AQEJCQ4VGR0dHR4fHyQrKy0tLS4uLi8xMTExMTExMjIyWVlZWlpkZGRm` is aiming to load the deck associated with that hash.

If you are not signed in it stays in the url, once at the main page it sends you to the deck screen, once at the deck screen it opens the import/export modal, once there it loads the hash and imports the deck.  It ALSO clears the url parameter so you can go about navigating now.