### PR TITLE
Fix bedinfo for consecutive bed use

### DIFF
--- a/server/cards/card-plugins/effects/bed.js
+++ b/server/cards/card-plugins/effects/bed.js
@@ -43,8 +43,7 @@ class BedEffectCard extends EffectCard {
 					const hasBed = row.effectCard?.cardId === this.id
 					if (!isSleeping && hasBed) {
 						discardCard(game, row.effectCard)
-					}
-					if (hasBed) bedInfo[rowIndex] = true
+					} else if (hasBed) bedInfo[rowIndex] = true
 				})
 				if (Object.keys(bedInfo).length > 0) {
 					playerState.custom[this.id] = bedInfo


### PR DESCRIPTION
bedInfo was being set to True even when the bed was discarded which prevented consecutive use of the bed.