### PR TITLE
Move the rank star on hermit cards 10 pixels down

### DIFF
--- a/client/src/components/card/hermit-card-svg.tsx
+++ b/client/src/components/card/hermit-card-svg.tsx
@@ -94,7 +94,7 @@ const HermitCardModule = ({card}: HermitCardProps) => {
 				<g>
 					<image
 						x="68"
-						y="70"
+						y="80"
 						width="70"
 						height="70"
 						href={`/images/ranks/${rank.name}.png`}


### PR DESCRIPTION
I made a mistake on my palettes PR, and now the stars display slightly too high. This should fix it.