### PR TITLE
Allow to pick less than the necessary amount of slots

### DIFF
--- a/client/src/app/game/game.tsx
+++ b/client/src/app/game/game.tsx
@@ -34,6 +34,7 @@ import {
 
 const getPickProcessMessage = (pickProcess: PickProcessT) => {
 	const req = pickProcess.requirments[pickProcess.currentReq]
+	const amount = pickProcess.amount || req.amount
 	const target =
 		req.target === 'board'
 			? "anyone's"
@@ -75,9 +76,9 @@ const getPickProcessMessage = (pickProcess: PickProcessT) => {
 	const empty = req.empty || false
 	const adjacent = req.adjacent || false
 	const name = pickProcess.name
-	return `${name}: Pick ${req.amount} ${empty ? 'empty' : ''} ${type} ${
+	return `${name}: Pick ${amount} ${empty ? 'empty' : ''} ${type} ${
 		empty ? 'slot' : 'card'
-	}${req.amount > 1 ? 's' : ''} ${adjacent ? 'adjacent to' : ''} ${
+	}${amount > 1 ? 's' : ''} ${adjacent ? 'adjacent to' : ''} ${
 		adjacent ? adjacentTarget : ''
 	} from ${target} ${location}.`
 }

--- a/client/src/logic/game/game-actions.ts
+++ b/client/src/logic/game/game-actions.ts
@@ -49,6 +49,7 @@ export const setPickProcess = (pickProcess: PickProcessT | null) => ({
 
 export const updatePickProcess = (payload: {
 	currentReq?: number
+	amount?: number
 	pickedSlots?: Array<PickedSlotT>
 }) => ({
 	type: 'UPDATE_PICK_PROCESS' as const,

--- a/client/src/logic/game/tasks/pick-process-saga.ts
+++ b/client/src/logic/game/tasks/pick-process-saga.ts
@@ -96,13 +96,13 @@ export function* runPickProcessSaga(
 
 		if (!name || !reqs || !playerId || !gameState) return null
 
-		const pickPossible = anyAvailableReqOptions(
+		const possiblePerReq = anyAvailableReqOptions(
 			gameState,
 			playerState,
 			opponentState,
 			reqs
 		)
-		if (!pickPossible) return []
+		if (possiblePerReq.length === 0) return []
 
 		// Listen for Escape to cancel
 		const escapeChannel = eventChannel((emitter) => {
@@ -131,10 +131,16 @@ export function* runPickProcessSaga(
 				const pickedReqSlots: Array<PickedSlotT> = []
 				const actionType =
 					req.target === 'hand' ? 'SET_SELECTED_CARD' : 'SLOT_PICKED'
+				const amount = Math.min(req.amount, possiblePerReq[reqIndex])
 
-				while (pickedReqSlots.length < req.amount) {
-					// Update currentReq, used to display the correct message
-					yield put(updatePickProcess({currentReq: Number(reqIndex)}))
+				while (pickedReqSlots.length < amount) {
+					// Update currentReq and amount, used to display the correct message
+					yield put(
+						updatePickProcess({
+							currentReq: Number(reqIndex),
+							amount: amount - pickedReqSlots.length,
+						})
+					)
 
 					// Wait for the user to pick a slot
 					const result = yield race({

--- a/common/types/pick-process.ts
+++ b/common/types/pick-process.ts
@@ -1,5 +1,5 @@
 import Card from '../cards/card-plugins/_card'
-import { Slot } from './cards'
+import {Slot} from './cards'
 import {CardT, RowState} from './game-state'
 
 export type SlotTypeT =
@@ -44,6 +44,7 @@ export type PickProcessT = {
 	requirments: Array<PickRequirmentT>
 	pickedSlots: Array<PickedSlotT>
 	currentReq: number
+	amount?: number
 }
 
 export type PickedSlots = Record<string, Array<PickedSlotT>>


### PR DESCRIPTION
This allows you to pick less than the required amount of slots when there are not enough valid slots on the board, for example when there are 2 hermits on the other side of the board you would be able to pick 2 hermits instead of 3 when using the Crossbow.

I also made it so the message changes as you pick slots, so the amount of slots on the message will decrease after you pick a slot.