### PR TITLE
Call hooks of everyone involved on an attack

### DIFF
--- a/common/cards/card-plugins/effects/chainmail-armor.js
+++ b/common/cards/card-plugins/effects/chainmail-armor.js
@@ -21,9 +21,9 @@ class ChainmailArmorEffectCard extends EffectCard {
 	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {otherPlayer} = pos
+		const {player} = pos
 
-		otherPlayer.hooks.onAttack[instance] = (attack, pickedSlots) => {
+		player.hooks.onAttack[instance] = (attack, pickedSlots) => {
 			if (attack.target.index !== pos.rowIndex || attack.type !== 'effect')
 				return
 			attack.reduceDamage(attack.damage)
@@ -37,8 +37,8 @@ class ChainmailArmorEffectCard extends EffectCard {
 	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
-		const {otherPlayer} = pos
-		delete otherPlayer.hooks.onAttack[instance]
+		const {player} = pos
+		delete player.hooks.onAttack[instance]
 	}
 
 	getExpansion() {

--- a/common/cards/card-plugins/effects/diamond-armor.js
+++ b/common/cards/card-plugins/effects/diamond-armor.js
@@ -25,7 +25,7 @@ class DiamondArmorEffectCard extends EffectCard {
 		const {otherPlayer, player} = pos
 		const instanceKey = this.getInstanceKey(instance)
 
-		otherPlayer.hooks.onAttack[instance] = (attack, pickedSlots) => {
+		player.hooks.onAttack[instance] = (attack, pickedSlots) => {
 			if (attack.target.index !== pos.rowIndex || attack.type === 'ailment')
 				return
 			if (attack.type === 'effect') {
@@ -59,7 +59,7 @@ class DiamondArmorEffectCard extends EffectCard {
 	 */
 	onDetach(game, instance, pos) {
 		const {otherPlayer, player} = pos
-		delete otherPlayer.hooks.onAttack[instance]
+		delete player.hooks.onAttack[instance]
 		delete otherPlayer.hooks.onTurnEnd[instance]
 		delete player.custom[this.getInstanceKey(instance)]
 	}

--- a/common/cards/card-plugins/effects/gold-armor.js
+++ b/common/cards/card-plugins/effects/gold-armor.js
@@ -24,7 +24,7 @@ class GoldArmorEffectCard extends EffectCard {
 		const {otherPlayer, player} = pos
 		const instanceKey = this.getInstanceKey(instance)
 
-		otherPlayer.hooks.onAttack[instance] = (attack, pickedSlots) => {
+		player.hooks.onAttack[instance] = (attack, pickedSlots) => {
 			if (attack.target.index !== pos.rowIndex || attack.type === 'ailment')
 				return
 
@@ -53,7 +53,7 @@ class GoldArmorEffectCard extends EffectCard {
 	 */
 	onDetach(game, instance, pos) {
 		const {otherPlayer, player} = pos
-		delete otherPlayer.hooks.onAttack[instance]
+		delete player.hooks.onAttack[instance]
 		delete otherPlayer.hooks.onTurnEnd[instance]
 		delete player.custom[this.getInstanceKey(instance)]
 	}

--- a/common/cards/card-plugins/effects/iron-armor.js
+++ b/common/cards/card-plugins/effects/iron-armor.js
@@ -24,7 +24,7 @@ class IronArmorEffectCard extends EffectCard {
 		const {otherPlayer, player} = pos
 		const instanceKey = this.getInstanceKey(instance)
 
-		otherPlayer.hooks.onAttack[instance] = (attack, pickedSlots) => {
+		player.hooks.onAttack[instance] = (attack, pickedSlots) => {
 			if (attack.target.index !== pos.rowIndex || attack.type === 'ailment')
 				return
 
@@ -53,7 +53,7 @@ class IronArmorEffectCard extends EffectCard {
 	 */
 	onDetach(game, instance, pos) {
 		const {otherPlayer, player} = pos
-		delete otherPlayer.hooks.onAttack[instance]
+		delete player.hooks.onAttack[instance]
 		delete otherPlayer.hooks.onTurnEnd[instance]
 		delete player.custom[this.getInstanceKey(instance)]
 	}

--- a/common/cards/card-plugins/effects/netherite-armor.js
+++ b/common/cards/card-plugins/effects/netherite-armor.js
@@ -24,9 +24,8 @@ class NetheriteArmorEffectCard extends EffectCard {
 	onAttach(game, instance, pos) {
 		const {otherPlayer, player, row} = pos
 		const instanceKey = this.getInstanceKey(instance)
-		const activeRowIndex = pos.player.board.activeRow
 
-		otherPlayer.hooks.onAttack[instance] = (attack, pickedSlots) => {
+		player.hooks.onAttack[instance] = (attack, pickedSlots) => {
 			if (attack.target.index !== pos.rowIndex || attack.type === 'ailment')
 				return
 			if (attack.type === 'effect') {
@@ -54,7 +53,7 @@ class NetheriteArmorEffectCard extends EffectCard {
 
 		otherPlayer.hooks.onApply[instance] = (instance) => {
 			// Prevent being knocked out
-			if (activeRowIndex === pos.rowIndex && row) {
+			if (player.board.activeRow === null && row) {
 				player.board.activeRow = pos.rowIndex
 				row.ailments = row.ailments.filter((a) => a.id !== 'knockedout')
 			}
@@ -68,7 +67,7 @@ class NetheriteArmorEffectCard extends EffectCard {
 	 */
 	onDetach(game, instance, pos) {
 		const {otherPlayer, player} = pos
-		delete otherPlayer.hooks.onAttack[instance]
+		delete player.hooks.onAttack[instance]
 		delete otherPlayer.hooks.onTurnEnd[instance]
 		delete otherPlayer.hooks.onApply[instance]
 		delete player.custom[this.getInstanceKey(instance)]

--- a/common/cards/card-plugins/effects/shield.js
+++ b/common/cards/card-plugins/effects/shield.js
@@ -26,7 +26,7 @@ class ShieldEffectCard extends EffectCard {
 		const {otherPlayer, player} = pos
 		const instanceKey = this.getInstanceKey(instance)
 
-		otherPlayer.hooks.onAttack[instance] = (attack, pickedSlots) => {
+		player.hooks.onAttack[instance] = (attack) => {
 			if (attack.target.index !== pos.rowIndex || attack.type === 'ailment')
 				return
 
@@ -43,7 +43,7 @@ class ShieldEffectCard extends EffectCard {
 			}
 		}
 
-		otherPlayer.hooks.afterAttack[instance] = (attackResult) => {
+		player.hooks.afterAttack[instance] = (attackResult) => {
 			const {player, row} = pos
 
 			if (player.custom[instanceKey] > 0 && row) {
@@ -63,8 +63,8 @@ class ShieldEffectCard extends EffectCard {
 	 */
 	onDetach(game, instance, pos) {
 		const {otherPlayer, player} = pos
-		delete otherPlayer.hooks.onAttack[instance]
-		delete otherPlayer.hooks.afterAttack[instance]
+		delete player.hooks.onAttack[instance]
+		delete player.hooks.afterAttack[instance]
 		delete otherPlayer.hooks.onTurnEnd[instance]
 		delete player.custom[this.getInstanceKey(instance)]
 	}

--- a/common/cards/card-plugins/effects/thorns.js
+++ b/common/cards/card-plugins/effects/thorns.js
@@ -19,15 +19,16 @@ class ThornsEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player, otherPlayer} = pos
+		const {player} = pos
 
-		otherPlayer.hooks.onAttack[instance] = (attack) => {
+		player.hooks.onAttack[instance] = (attack) => {
 			if (!['primary', 'secondary', 'zero'].includes(attack.type)) return
 
-			if (attack.attacker && player.board.activeRow === pos.rowIndex) {
+			if (player.board.activeRow === pos.rowIndex && attack.attacker) {
 				const backlashAttack = new AttackModel({
 					id: this.getInstanceKey(instance, 'backlash'),
 					target: attack.attacker,
+					attacker: attack.target,
 					type: 'backlash',
 				}).addDamage(10)
 
@@ -45,7 +46,7 @@ class ThornsEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
-		delete pos.otherPlayer.hooks.onAttack[instance]
+		delete pos.player.hooks.onAttack[instance]
 	}
 }
 

--- a/common/cards/card-plugins/effects/thorns_ii.js
+++ b/common/cards/card-plugins/effects/thorns_ii.js
@@ -19,15 +19,16 @@ class ThornsIIEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player, otherPlayer} = pos
+		const {player} = pos
 
-		otherPlayer.hooks.onAttack[instance] = (attack) => {
+		player.hooks.onAttack[instance] = (attack) => {
 			if (!['primary', 'secondary', 'zero'].includes(attack.type)) return
 
-			if (attack.attacker && player.board.activeRow === pos.rowIndex) {
+			if (player.board.activeRow === pos.rowIndex && attack.attacker) {
 				const backlashAttack = new AttackModel({
 					id: this.getInstanceKey(instance, 'backlash'),
 					target: attack.attacker,
+					attacker: attack.target,
 					type: 'backlash',
 				}).addDamage(20)
 
@@ -45,7 +46,7 @@ class ThornsIIEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
-		delete pos.otherPlayer.hooks.onAttack[instance]
+		delete pos.player.hooks.onAttack[instance]
 	}
 
 	getExpansion() {

--- a/common/cards/card-plugins/effects/thorns_iii.js
+++ b/common/cards/card-plugins/effects/thorns_iii.js
@@ -19,17 +19,18 @@ class ThornsIIIEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player, otherPlayer} = pos
+		const {player} = pos
 
-		otherPlayer.hooks.onAttack[instance] = (attack) => {
+		player.hooks.onAttack[instance] = (attack) => {
 			if (!['primary', 'secondary', 'zero'].includes(attack.type)) return
 
-			if (attack.attacker && player.board.activeRow === pos.rowIndex) {
+			if (player.board.activeRow === pos.rowIndex && attack.attacker) {
 				const backlashAttack = new AttackModel({
 					id: this.getInstanceKey(instance, 'backlash'),
 					target: attack.attacker,
+					attacker: attack.target,
 					type: 'backlash',
-				}).addDamage(30)
+				}).addDamage(10)
 
 				attack.addNewAttack(backlashAttack)
 			}
@@ -45,7 +46,7 @@ class ThornsIIIEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
-		delete pos.otherPlayer.hooks.onAttack[instance]
+		delete pos.player.hooks.onAttack[instance]
 	}
 
 	getExpansion() {

--- a/common/cards/card-plugins/effects/totem.js
+++ b/common/cards/card-plugins/effects/totem.js
@@ -19,7 +19,7 @@ class TotemEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		pos.otherPlayer.hooks.afterAttack[instance] = (result) => {
+		pos.player.hooks.afterAttack[instance] = (result) => {
 			const targetRow = result.attack.target.row
 			if (!targetRow || targetRow.health) return
 			if (targetRow.effectCard?.cardInstance !== instance) return
@@ -37,7 +37,7 @@ class TotemEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
-		delete pos.otherPlayer.hooks.afterAttack[instance]
+		delete pos.player.hooks.afterAttack[instance]
 	}
 }
 

--- a/common/cards/card-plugins/effects/wolf.js
+++ b/common/cards/card-plugins/effects/wolf.js
@@ -21,13 +21,15 @@ class WolfEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		pos.otherPlayer.hooks.onAttack[instance] = (attack) => {
+		const {player} = pos
+		player.hooks.onAttack[instance] = (attack) => {
 			if (!['primary', 'secondary', 'zero'].includes(attack.type)) return
 
 			if (attack.attacker && attack.target.index === pos.rowIndex) {
 				const backlashAttack = new AttackModel({
 					id: this.getInstanceKey(instance, 'backlash'),
 					target: attack.attacker,
+					attacker: attack.target,
 					type: 'backlash',
 				})
 				backlashAttack.addDamage(20)
@@ -58,7 +60,7 @@ class WolfEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
-		delete pos.otherPlayer.hooks.onAttack[instance]
+		delete pos.player.hooks.onAttack[instance]
 	}
 }
 

--- a/common/cards/card-plugins/hermits/_hermit-card.js
+++ b/common/cards/card-plugins/hermits/_hermit-card.js
@@ -65,10 +65,12 @@ class HermitCard extends Card {
 			attacker: {
 				index: pos.rowIndex,
 				row: pos.row,
+				playerId: pos.playerId,
 			},
 			target: {
 				index: targetIndex,
 				row: targetRow,
+				playerId: pos.otherPlayerId,
 			},
 			type: hermitAttackType,
 		})

--- a/common/cards/card-plugins/hermits/goatfather-rare.js
+++ b/common/cards/card-plugins/hermits/goatfather-rare.js
@@ -71,10 +71,12 @@ class GoatfatherRareHermitCard extends HermitCard {
 				attacker: {
 					index: rowIndex,
 					row: row,
+					playerId: player.id,
 				},
 				target: {
 					index: i,
 					row: targetRow,
+					playerId: otherPlayer.id,
 				},
 				type: hermitAttackType,
 			}).addDamage(activeRow === i ? 30 : 10)

--- a/common/cards/card-plugins/hermits/goodtimeswithscar-rare.js
+++ b/common/cards/card-plugins/hermits/goodtimeswithscar-rare.js
@@ -45,9 +45,8 @@ class GoodTimesWithScarRareHermitCard extends HermitCard {
 			player.custom[reviveNextTurn] = true
 		}
 
-		otherPlayer.hooks.afterAttack[instance] = (afterAttack) => {
+		player.hooks.afterAttack[instance] = (afterAttack) => {
 			if (afterAttack.attack.target.index !== rowIndex) return
-
 			if (player.custom[reviveNextTurn] && !player.custom[scarRevivedKey]) {
 				if (!row || row.health === null || row.health > 0) {
 					return
@@ -72,7 +71,7 @@ class GoodTimesWithScarRareHermitCard extends HermitCard {
 		const scarRevivedKey = this.getInstanceKey(instance, 'revived')
 		// Remove hooks
 		delete player.hooks.onAttack[instance]
-		delete otherPlayer.hooks.afterAttack[instance]
+		delete player.hooks.afterAttack[instance]
 		delete player.custom[reviveNextTurn]
 		delete player.custom[scarRevivedKey]
 	}

--- a/common/cards/card-plugins/hermits/hypnotizd-rare.js
+++ b/common/cards/card-plugins/hermits/hypnotizd-rare.js
@@ -70,6 +70,7 @@ class HypnotizdRareHermitCard extends HermitCard {
 			attack.target = {
 				index: pickedHermit.row.index,
 				row: pickedHermit.row.state,
+				playerId: otherPlayer.id,
 			}
 
 			const pickedItem = pickedSlots[this.id]?.[1]

--- a/common/cards/card-plugins/hermits/potatoboy-rare.js
+++ b/common/cards/card-plugins/hermits/potatoboy-rare.js
@@ -1,7 +1,6 @@
 import HermitCard from './_hermit-card'
 import {HERMIT_CARDS} from '../../../cards'
 import {GameModel} from '../../../../server/models/game-model'
-import {AttackModel} from '../../../../server/models/attack-model'
 
 class PotatoBoyRareHermitCard extends HermitCard {
 	constructor() {

--- a/common/cards/card-plugins/single-use/_single-use-card.js
+++ b/common/cards/card-plugins/single-use/_single-use-card.js
@@ -1,4 +1,3 @@
-import {AttackModel} from '../../../../server/models/attack-model'
 import {GameModel} from '../../../../server/models/game-model'
 import Card from '../_card'
 

--- a/common/cards/card-plugins/single-use/anvil.js
+++ b/common/cards/card-plugins/single-use/anvil.js
@@ -48,10 +48,12 @@ class AnvilSingleUseCard extends SingleUseCard {
 					attacker: {
 						index: activeRow,
 						row: row,
+						playerId: player.id,
 					},
 					target: {
 						index: i,
 						row: opponentRow,
+						playerId: otherPlayer.id,
 					},
 					type: 'effect',
 				}).addDamage(i === activeRow ? 30 : 10)

--- a/common/cards/card-plugins/single-use/bow.js
+++ b/common/cards/card-plugins/single-use/bow.js
@@ -60,8 +60,12 @@ class BowSingleUseCard extends SingleUseCard {
 
 			const bowAttack = new AttackModel({
 				id: this.getInstanceKey(instance),
-				attacker: {index, row},
-				target: {index: opponentIndex, row: opponentRow},
+				attacker: {index, row, playerId: player.id},
+				target: {
+					index: opponentIndex,
+					row: opponentRow,
+					playerId: otherPlayer.id,
+				},
 				type: 'effect',
 			}).addDamage(40)
 

--- a/common/cards/card-plugins/single-use/crossbow.js
+++ b/common/cards/card-plugins/single-use/crossbow.js
@@ -28,7 +28,7 @@ class CrossbowSingleUseCard extends SingleUseCard {
 	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player} = pos
+		const {player, otherPlayer} = pos
 
 		player.hooks.getAttacks[instance] = (pickedSlots) => {
 			const index = player.board.activeRow
@@ -43,8 +43,12 @@ class CrossbowSingleUseCard extends SingleUseCard {
 				attacks.push(
 					new AttackModel({
 						id: this.getInstanceKey(instance),
-						attacker: {index, row},
-						target: {index: slot.row.index, row: slot.row.state},
+						attacker: {index, row, playerId: player.id},
+						target: {
+							index: slot.row.index,
+							row: slot.row.state,
+							playerId: otherPlayer.id,
+						},
 						type: 'effect',
 					}).addDamage(20)
 				)

--- a/common/cards/card-plugins/single-use/diamond-sword.js
+++ b/common/cards/card-plugins/single-use/diamond-sword.js
@@ -34,7 +34,16 @@ class DiamondSwordSingleUseCard extends SingleUseCard {
 
 			const swordAttack = new AttackModel({
 				id: this.getInstanceKey(instance, 'attack'),
-				target: {index: opponentIndex, row: opponentRow},
+				target: {
+					index: opponentIndex,
+					row: opponentRow,
+					playerId: otherPlayer.id,
+				},
+				attacker: {
+					index: index,
+					row: row,
+					playerId: player.id,
+				},
 				type: 'effect',
 			}).addDamage(40)
 

--- a/common/cards/card-plugins/single-use/egg.js
+++ b/common/cards/card-plugins/single-use/egg.js
@@ -37,8 +37,10 @@ class EggSingleUseCard extends SingleUseCard {
 			if (pickedSlot.length !== 1) return
 			const pickedHermit = pickedSlot[0]
 			if (!pickedHermit.row || !pickedHermit.row.state.hermitCard) return
-
-			applySingleUse(game)
+			const activeRow = player.board.activeRow
+			if (activeRow === null) return
+			const row = player.board.rows[activeRow]
+			if (!row || !row.hermitCard) return
 
 			const coinFlip = flipCoin(player, this.id)
 			player.coinFlips[this.id] = coinFlip
@@ -48,6 +50,12 @@ class EggSingleUseCard extends SingleUseCard {
 					target: {
 						index: pickedHermit.row.index,
 						row: pickedHermit.row.state,
+						playerId: otherPlayer.id,
+					},
+					attacker: {
+						index: activeRow,
+						row: row,
+						playerId: player.id,
 					},
 					type: 'effect',
 				}).addDamage(10)
@@ -64,6 +72,7 @@ class EggSingleUseCard extends SingleUseCard {
 		player.hooks.afterAttack[instance] = (attackResult) => {
 			const eggIndex = player.custom[this.getInstanceKey(instance)]
 			otherPlayer.board.activeRow = eggIndex
+			applySingleUse(game)
 		}
 	}
 

--- a/common/cards/card-plugins/single-use/golden-axe.js
+++ b/common/cards/card-plugins/single-use/golden-axe.js
@@ -60,8 +60,12 @@ class GoldenAxeSingleUseCard extends SingleUseCard {
 			const multiplier = getItemCardsEnergy(game, opponentRow)
 			const attack = new AttackModel({
 				id: this.getInstanceKey(instance),
-				attacker: {index, row},
-				target: {index: opponentIndex, row: opponentRow},
+				attacker: {index, row, playerId: player.id},
+				target: {
+					index: opponentIndex,
+					row: opponentRow,
+					playerId: otherPlayer.id,
+				},
 				type: 'effect',
 			}).addDamage(Math.min(80, 20 * multiplier))
 

--- a/common/cards/card-plugins/single-use/iron-sword.js
+++ b/common/cards/card-plugins/single-use/iron-sword.js
@@ -34,7 +34,12 @@ class IronSwordSingleUseCard extends SingleUseCard {
 
 			const swordAttack = new AttackModel({
 				id: this.getInstanceKey(instance, 'attack'),
-				target: {index: opponentIndex, row: opponentRow},
+				target: {
+					index: opponentIndex,
+					row: opponentRow,
+					playerId: otherPlayer.id,
+				},
+				attacker: {index: index, row: row, playerId: player.id},
 				type: 'effect',
 			}).addDamage(20)
 

--- a/common/cards/card-plugins/single-use/netherite-sword.js
+++ b/common/cards/card-plugins/single-use/netherite-sword.js
@@ -34,7 +34,16 @@ class NetheriteSwordSingleUseCard extends SingleUseCard {
 
 			const swordAttack = new AttackModel({
 				id: this.getInstanceKey(instance, 'attack'),
-				target: {index: opponentIndex, row: opponentRow},
+				target: {
+					index: opponentIndex,
+					row: opponentRow,
+					playerId: otherPlayer.id,
+				},
+				attacker: {
+					index,
+					row,
+					playerId: player.id,
+				},
 				type: 'effect',
 			}).addDamage(60)
 

--- a/common/cards/card-plugins/single-use/tnt.js
+++ b/common/cards/card-plugins/single-use/tnt.js
@@ -34,13 +34,22 @@ class TNTSingleUseCard extends SingleUseCard {
 
 			const tntAttack = new AttackModel({
 				id: this.getInstanceKey(instance, 'attack'),
-				target: {index: opponentIndex, row: opponentRow},
+				target: {
+					index: opponentIndex,
+					row: opponentRow,
+					playerId: otherPlayer.id,
+				},
+				attacker: {
+					index,
+					row,
+					playerId: player.id,
+				},
 				type: 'effect',
 			}).addDamage(60)
 
 			const backlashAttack = new AttackModel({
 				id: this.getInstanceKey(instance, 'backlash'),
-				target: {index, row},
+				target: {index, row, playerId: player.id},
 				type: 'backlash',
 			}).addDamage(20)
 

--- a/common/cards/card-plugins/single-use/trident.js
+++ b/common/cards/card-plugins/single-use/trident.js
@@ -43,8 +43,12 @@ class TridentSingleUseCard extends SingleUseCard {
 
 			const tridentAttack = new AttackModel({
 				id: this.getInstanceKey(instance),
-				attacker: {index, row},
-				target: {index: opponentIndex, row: opponentRow},
+				attacker: {index, row, playerId: player.id},
+				target: {
+					index: opponentIndex,
+					row: opponentRow,
+					playerId: otherPlayer.id,
+				},
 				type: 'effect',
 			}).addDamage(30)
 

--- a/common/types/game-state.ts
+++ b/common/types/game-state.ts
@@ -13,7 +13,14 @@ export type CardT = {
 }
 
 export type Ailment = {
-	id: 'poison' | 'fire' | 'sleeping' | 'knockedout' | 'slowness' | 'badomen' | 'weakness'
+	id:
+		| 'poison'
+		| 'fire'
+		| 'sleeping'
+		| 'knockedout'
+		| 'slowness'
+		| 'badomen'
+		| 'weakness'
 	duration: number
 }
 
@@ -38,6 +45,7 @@ export type RowState = RowStateWithHermit | RowStateWithoutHermit
 export type RowInfo = {
 	index: number
 	row: RowStateWithHermit
+	playerId: PlayerId
 }
 
 export type CoinFlipT = 'heads' | 'tails'
@@ -106,7 +114,9 @@ export type PlayerState = {
 		afterAttack: Hook<(attackResult: AttackResult) => void>
 
 		/** Instance key -> hook called on follow up */
-		onFollowUp: Hook<(followUp: string, pickedSlots: PickedSlots, modalResult: any) => void>
+		onFollowUp: Hook<
+			(followUp: string, pickedSlots: PickedSlots, modalResult: any) => void
+		>
 		/** Instance key -> hook called when follow up times out */
 		onFollowUpTimeout: Hook<(followUp: string) => void>
 

--- a/config/debug-config.json
+++ b/config/debug-config.json
@@ -1,7 +1,12 @@
 {
-	"disableDeckValidation": false,
+	"disableDeckValidation": true,
 	"extraStartingCards": [],
-	"noItemRequirements": false,
-	"forceCoinFlip": false,
-	"oneShotMode": false
+	"noItemRequirements": true,
+	"forceCoinFlip": true,
+	"oneShotMode": false,
+	"disableDamage": false,
+	"startWithAllCards": true,
+	"disableDeckout": true,
+	"blockedActions": [],
+	"availableActions": ["ZERO_ATTACK"]
 }

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -355,7 +355,7 @@ export function getNonEmptyRows(playerState, includeActive = true) {
 	for (let i = 0; i < playerState.board.rows.length; i++) {
 		const row = playerState.board.rows[i]
 		if (i === activeRowIndex && !includeActive) continue
-		if (row.hermitCard) rows.push({index: i, row})
+		if (row.hermitCard) rows.push({index: i, row, playerId: playerState.id})
 	}
 	return rows
 }


### PR DESCRIPTION
Instead of implementing onDefence I decided to do this instead of adding more hooks that basically did the same, now if the attack has an attacker the hooks of the attacker are going to be called if they exists and the same for the target.

The hooks are called for the attacker first the reason being that you want to modify the attack (doc, mumbo, etc) before it gets locked by the target (armor, pearl etc). This also has the benefit that we can play with order pretty easily, the attacker is going to call its hooks first, I'm sure that's going to come handy for something.

A side effect of this is that I had to add an attacker to the cards that didn't had one (swords, egg, etc), the attacker still needs to be optional because ailment attacks can't have an attacker, well at least you can't be the attacker because the hooks would be called twice.

This fixes Armor, Thorns, Totem, Scar, and probably other cards too.

I also added an option to disable damage and fixed weakness attacks being created for zero attacks.