### PR TITLE
Fix the obsidian outline on AE prankster cards

### DIFF
--- a/client/src/components/card/hermit-card-svg.module.scss
+++ b/client/src/components/card/hermit-card-svg.module.scss
@@ -91,7 +91,8 @@ text.attackName {
 }
 
 .attackItems.alter_egos.prankster {
-	filter: drop-shadow(2px 2px 0 white) drop-shadow(-2px -2px 0 white);
+	filter: drop-shadow(1px 1px 0 white) drop-shadow(-2px 0px 0 white)
+		drop-shadow(1px -1px 0 white);
 }
 
 .rank {


### PR DESCRIPTION
Small change, and not that urgent, but it was pretty quick so I just wanted to get it done. Now the outline looks a lot nicer than before.

| Before | After |
--------|-------
|![image](https://github.com/martinkadlec0/hc-tcg/assets/63879236/4cf40a01-b68a-4e98-8041-ee4f78303a0d) | ![image](https://github.com/martinkadlec0/hc-tcg/assets/63879236/5134972c-4e64-4360-8f34-2a6afd9ad8a6) |
