### PR TITLE
Fixed ailments lasting 1 turn less than they should

### DIFF
--- a/common/cards/card-plugins/effects/bed.js
+++ b/common/cards/card-plugins/effects/bed.js
@@ -54,11 +54,11 @@ class BedEffectCard extends EffectCard {
 			// Clear any previous sleeping
 			row.ailments = row.ailments.filter((a) => a.id !== 'sleeping')
 
-			// Set new sleeping for two more turns
-			row.ailments.push({id: 'sleeping', duration: 2})
+			// Set new sleeping for 3 turns (2 + the current turn)
+			row.ailments.push({id: 'sleeping', duration: 3})
 		}
 
-		player.hooks.onTurnStart[instance] = () => {
+		player.hooks.onTurnEnd[instance] = () => {
 			const isSleeping = row?.ailments.some((a) => a.id === 'sleeping')
 
 			// if sleeping has worn off, discard the bed

--- a/common/cards/card-plugins/hermits/bdoubleo100-rare.js
+++ b/common/cards/card-plugins/hermits/bdoubleo100-rare.js
@@ -50,8 +50,8 @@ class BdoubleO100RareHermitCard extends HermitCard {
 				(a) => a.id !== 'sleeping'
 			)
 
-			// sleep for 2 turns
-			attacker.row.ailments.push({id: 'sleeping', duration: 2})
+			// sleep for 3 turns (2 + the current turn)
+			attacker.row.ailments.push({id: 'sleeping', duration: 3})
 		}
 	}
 

--- a/server/routines/game.js
+++ b/server/routines/game.js
@@ -582,6 +582,22 @@ function* turnSaga(game) {
 	// Run the ailment attacks just before turn end
 	runAilmentAttacks(game, opponentPlayer)
 
+	// ailment logic
+
+	// row ailments
+	for (let row of currentPlayer.board.rows) {
+		for (let ailment of row.ailments) {
+			// decrease duration
+			if (ailment.duration > -1) {
+				// ailment is not infinite, reduce duration by 1
+				ailment.duration--
+			}
+		}
+
+		// Get rid of ailments that have expired
+		row.ailments = row.ailments.filter((a) => a.duration > 0)
+	}
+
 	// Call turn end hooks
 	const turnEndHooks = Object.values(currentPlayer.hooks.onTurnEnd)
 	for (let i = 0; i < turnEndHooks.length; i++) {
@@ -616,22 +632,6 @@ function* turnSaga(game) {
 		game.endInfo.reason = 'cards'
 		game.endInfo.deadPlayerIds = [currentPlayerId]
 		return 'GAME_END'
-	}
-
-	// ailment logic
-
-	// row ailments
-	for (let row of currentPlayer.board.rows) {
-		for (let ailment of row.ailments) {
-			// decrease duration
-			if (ailment.duration === 1) {
-				// time up, get rid of this ailment
-				row.ailments = row.ailments.filter((a) => a.id !== ailment.id)
-			} else if (ailment.duration > -1) {
-				// ailment is not infinite, reduce duration by 1
-				ailment.duration--
-			}
-		}
 	}
 
 	return 'DONE'


### PR DESCRIPTION
Originally I moved the aliment logic back to where it was before but then I realized that because of the changes to flipCoin it means that Bad Omen can't stay active until the start of your turn which meant that if you tossed a coin Bad Omen was staying active when it shouldn't, that means that if I wanted it to work properly I needed to change the bed to be removed at the end of your turn otherwise the hermit would have a bed without sleeping at the end of their turn.

One thing to keep in mind is that because the aliment logic was moved to the end of the turn you need to set the aliment to last 1 extra turn if you are applying an ailment to the current player.