### PR TITLE
Move turtle shell to being discarded at end of opponent's turn

### DIFF
--- a/common/cards/card-plugins/effects/turtle-shell.js
+++ b/common/cards/card-plugins/effects/turtle-shell.js
@@ -64,7 +64,7 @@ class TurtleShellEffectCard extends EffectCard {
 	 * @param {import('../../../types/cards').CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player} = pos
+		const {player, opponentPlayer} = pos
 		const instanceKey = this.getInstanceKey(instance)
 
 		// Store whether we blocked any damage
@@ -83,7 +83,7 @@ class TurtleShellEffectCard extends EffectCard {
 			}
 		}
 
-		player.hooks.afterDefence[instance] = (attack) => {
+		opponentPlayer.hooks.onTurnEnd[instance] = () => {
 			if (player.custom[instanceKey] === true) {
 				discardCard(game, {cardId: this.id, cardInstance: instance})
 			}

--- a/common/cards/card-plugins/effects/turtle-shell.js
+++ b/common/cards/card-plugins/effects/turtle-shell.js
@@ -36,7 +36,7 @@ class TurtleShellEffectCard extends EffectCard {
 			name: 'Turtle Shell',
 			rarity: 'rare',
 			description:
-				'Attach to any of your afk hermits. When the hermit is made active, it prevents any damage for its first turn and then is discarded.',
+				"Attach to any of your AFK Hermits. When that Hermit becomes active, this card prevents any damage for that Hermit's first turn, and is then discarded.",
 		})
 	}
 


### PR DESCRIPTION
Before, the turtle shell was discarded after the opponent's attack which caused 2 issues.
- If the opponent did not attack, turtle shell would be active an extra round.
- Gem could deal damage with her second effect.

Also, the description was incorrect and had a few typos, so I corrected those as well.