### PR TITLE
Make sure turtle shell only blocks damage done by the opponent

### DIFF
--- a/common/cards/card-plugins/effects/turtle-shell.js
+++ b/common/cards/card-plugins/effects/turtle-shell.js
@@ -36,7 +36,7 @@ class TurtleShellEffectCard extends EffectCard {
 			name: 'Turtle Shell',
 			rarity: 'rare',
 			description:
-				"Attach to any of your AFK Hermits. When that Hermit becomes active, this card prevents any damage for that Hermit's first turn, and is then discarded.",
+				"Attach to any of your AFK Hermits. When that Hermit becomes active, this card prevents any damage done by your opponent for that Hermit's first turn, and is then discarded.",
 		})
 	}
 
@@ -74,6 +74,8 @@ class TurtleShellEffectCard extends EffectCard {
 			// Only block damage when we are active
 			const isActive = player.board.activeRow === pos.rowIndex
 			if (!isActive || !isTargetingPos(attack, pos)) return
+			// Do not block backlash attacks
+			if (attack.isBacklash) return
 
 			if (attack.getDamage() > 0) {
 				// Block all damage


### PR DESCRIPTION
It used to do this, but I believe this stopped working when it was switched to use the onDefence hook.

I also updated the description to make it more clear. I realized it was wrong before:

Before - `Attach to any of your AFK Hermits. When that Hermit becomes active, this card prevents any damage for that Hermit's first turn, and is then discarded.`

After - `Attach to any of your AFK Hermits. When that Hermit becomes active, this card prevents any damage done by your opponent for that Hermit's first turn, and is then discarded.`

This means the same thing as the description on HC, but I rewrote to hopefully be a bit less confusing. The description before was incorrect (sorry!)