### PR TITLE
Human cleo bed and timeout fix

### DIFF
--- a/common/cards/card-plugins/hermits/humancleo-rare.js
+++ b/common/cards/card-plugins/hermits/humancleo-rare.js
@@ -124,6 +124,9 @@ class HumanCleoRareHermitCard extends HermitCard {
 
 				const weaknessAttack = createWeaknessAttack(attack)
 				if (weaknessAttack) newAttacks.push(weaknessAttack)
+
+				delete player.custom['opponent-attack']
+				delete opponentPlayer.hooks.beforeAttack[instance]
 			}
 
 			opponentPlayer.hooks.onAttack[instance] = (attack) => {
@@ -158,18 +161,19 @@ class HumanCleoRareHermitCard extends HermitCard {
 
 				const activeHermitInfo = HERMIT_CARDS[opponentActiveRow.row.hermitCard.cardId]
 
+				const isSleeping = opponentActiveRow.row.ailments.some((a) => a.id === 'sleeping')
+				if (isSleeping) return blockedActions
+
 				if (
-					hasEnoughEnergy(energyTypes, activeHermitInfo.primary.cost) ||
-					hasEnoughEnergy(energyTypes, activeHermitInfo.secondary.cost)
+					!hasEnoughEnergy(energyTypes, activeHermitInfo.primary.cost) &&
+					!hasEnoughEnergy(energyTypes, activeHermitInfo.secondary.cost)
 				) {
-					blockedActions.push('END_TURN')
+					return blockedActions
 				}
 
-				return blockedActions
-			}
+				blockedActions.push('END_TURN')
 
-			opponentPlayer.hooks.onTurnEnd[instance] = () => {
-				delete player.custom[instance]
+				return blockedActions
 			}
 		}
 


### PR DESCRIPTION
The interaction with Bed has been fixed: the `END_TURN` action is no longer locked if the opposing hermit is sleeping.

In addition, when the turn is timed out Human Cleo's ability does not carry over onto the next turn.