### PR TITLE
Transformed CardPos into a Class

### DIFF
--- a/common/cards/card-plugins/_card.js
+++ b/common/cards/card-plugins/_card.js
@@ -1,10 +1,10 @@
 // TODO - more validations (types, rarirites, other fields, ...)
 
 import {GameModel} from '../../../server/models/game-model'
+import CardPos from '../../../server/models/card-pos-model'
 
 /**
  * @typedef {import("../../types/cards").CardDefs} CardDefs
- * @typedef {import("../../types/cards").CardPos} CardPos
  * @typedef {import("../../types/cards").CardTypeT} CardTypeT
  * @typedef {import("../../types/cards").CardRarityT} CardRarityT
  * @typedef {import("../../../server/utils/reqs").PickRequirmentT} PickRequirmentT

--- a/common/cards/card-plugins/effects/_effect-card.js
+++ b/common/cards/card-plugins/effects/_effect-card.js
@@ -1,10 +1,10 @@
 import {AttackModel} from '../../../../server/models/attack-model'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import Card from '../_card'
 
 /**
  * @typedef {import('common/types/cards').EffectDefs} EffectDefs
- * @typedef {import('../../../types/cards').CardPos} CardPos
  * @typedef {import('../../../types/cards').CardTypeT} CardTypeT
  */
 
@@ -39,7 +39,7 @@ class EffectCard extends Card {
 		const {currentPlayer} = game.ds
 
 		// Wrong slot
-		if (pos.slot.type !== 'effect') return 'INVALID'
+		if (!pos.slot || pos.slot.type !== 'effect') return 'INVALID'
 		if (pos.player.id !== currentPlayer.id) return 'INVALID'
 
 		// Can't attach without hermit card - this is considered like the wrong slot

--- a/common/cards/card-plugins/effects/chainmail-armor.js
+++ b/common/cards/card-plugins/effects/chainmail-armor.js
@@ -1,10 +1,7 @@
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
 import EffectCard from './_effect-card'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class ChainmailArmorEffectCard extends EffectCard {
 	constructor() {

--- a/common/cards/card-plugins/effects/command-block.js
+++ b/common/cards/card-plugins/effects/command-block.js
@@ -1,11 +1,9 @@
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
-import {HERMIT_CARDS} from '../../../../common/cards'
-import {hasEnoughEnergy} from '../../../../server/utils'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class CommandBlockEffectCard extends EffectCard {

--- a/common/cards/card-plugins/effects/diamond-armor.js
+++ b/common/cards/card-plugins/effects/diamond-armor.js
@@ -1,10 +1,7 @@
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
 import EffectCard from './_effect-card'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class DiamondArmorEffectCard extends EffectCard {
 	constructor() {

--- a/common/cards/card-plugins/effects/gold-armor.js
+++ b/common/cards/card-plugins/effects/gold-armor.js
@@ -1,10 +1,7 @@
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class GoldArmorEffectCard extends EffectCard {
 	constructor() {

--- a/common/cards/card-plugins/effects/iron-armor.js
+++ b/common/cards/card-plugins/effects/iron-armor.js
@@ -1,10 +1,7 @@
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
 import EffectCard from './_effect-card'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class IronArmorEffectCard extends EffectCard {
 	constructor() {

--- a/common/cards/card-plugins/effects/lightning-rod.js
+++ b/common/cards/card-plugins/effects/lightning-rod.js
@@ -1,12 +1,8 @@
 import {discardCard} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import EffectCard from './_effect-card'
-import {getCardAtPos} from '../../../../server/utils/cards'
 import {isTargetingPos} from '../../../../server/utils/attacks'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class LightningRodEffectCard extends EffectCard {
 	constructor() {
@@ -42,10 +38,11 @@ class LightningRodEffectCard extends EffectCard {
 	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player, opponentPlayer, row, rowIndex} = pos
+		const {player, opponentPlayer} = pos
 
 		// Only on opponents turn
 		opponentPlayer.hooks.beforeAttack[instance] = (attack) => {
+			const {rowIndex, row} = pos
 			if (attack.isType('ailment') || attack.isBacklash) return
 			if (!row || rowIndex === null || !row.hermitCard) return
 
@@ -63,7 +60,7 @@ class LightningRodEffectCard extends EffectCard {
 			if (!isTargetingPos(attack, pos)) return
 			if (attack.calculateDamage() <= 0) return
 
-			discardCard(game, getCardAtPos(game, pos))
+			discardCard(game, pos.card)
 		}
 	}
 

--- a/common/cards/card-plugins/effects/loyalty.js
+++ b/common/cards/card-plugins/effects/loyalty.js
@@ -1,6 +1,7 @@
 import EffectCard from './_effect-card'
 import {moveCardToHand} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class LoyaltyEffectCard extends EffectCard {
 	constructor() {
@@ -16,7 +17,7 @@ class LoyaltyEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -39,7 +40,7 @@ class LoyaltyEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/effects/milk-bucket.js
+++ b/common/cards/card-plugins/effects/milk-bucket.js
@@ -1,4 +1,5 @@
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import EffectCard from './_effect-card'
 
 class MilkBucketEffectCard extends EffectCard {
@@ -17,10 +18,11 @@ class MilkBucketEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player, opponentPlayer, slot, row} = pos
+		const {player, opponentPlayer, slot} = pos
+		if (!slot) return
 		if (slot.type === 'single_use') {
 			player.hooks.onApply[instance] = (pickedSlots, modalResult) => {
 				const pickedCards = pickedSlots[this.id] || []
@@ -34,13 +36,13 @@ class MilkBucketEffectCard extends EffectCard {
 			}
 		} else if (slot.type === 'effect') {
 			player.hooks.onDefence[instance] = (attack, pickedSlots) => {
-				if (!row) return
-				row.ailments = row.ailments.filter((a) => a.id !== 'poison')
+				if (!pos.row) return
+				pos.row.ailments = pos.row.ailments.filter((a) => a.id !== 'poison')
 			}
 
 			opponentPlayer.hooks.afterApply[instance] = (attack, pickedSlots) => {
-				if (!row) return
-				row.ailments = row.ailments.filter((a) => a.id !== 'poison')
+				if (!pos.row) return
+				pos.row.ailments = pos.row.ailments.filter((a) => a.id !== 'poison')
 			}
 		}
 	}
@@ -48,7 +50,7 @@ class MilkBucketEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -59,10 +61,10 @@ class MilkBucketEffectCard extends EffectCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
-		if (!['single_use', 'effect'].includes(pos.slot.type)) return 'INVALID'
+		if (!pos.slot || !['single_use', 'effect'].includes(pos.slot.type)) return 'INVALID'
 		if (!pos.row?.hermitCard && pos.slot.type === 'effect') return 'NO'
 
 		return 'YES'

--- a/common/cards/card-plugins/effects/netherite-armor.js
+++ b/common/cards/card-plugins/effects/netherite-armor.js
@@ -1,10 +1,7 @@
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
 import EffectCard from './_effect-card'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class NetheriteArmorEffectCard extends EffectCard {
 	constructor() {

--- a/common/cards/card-plugins/effects/shield.js
+++ b/common/cards/card-plugins/effects/shield.js
@@ -1,11 +1,8 @@
 import EffectCard from './_effect-card'
 import {discardCard} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class ShieldEffectCard extends EffectCard {
 	constructor() {

--- a/common/cards/card-plugins/effects/string.js
+++ b/common/cards/card-plugins/effects/string.js
@@ -1,5 +1,6 @@
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class StringEffectCard extends EffectCard {
 	constructor() {
@@ -14,13 +15,13 @@ class StringEffectCard extends EffectCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
 		const {opponentPlayer} = game.ds
 
 		// attach to effect or item slot
-		if (pos.slot.type !== 'effect' && pos.slot.type !== 'item') return 'INVALID'
+		if (!pos.slot || (pos.slot.type !== 'effect' && pos.slot.type !== 'item')) return 'INVALID'
 
 		// can only attach to opponent
 		if (pos.player.id !== opponentPlayer.id) return 'INVALID'

--- a/common/cards/card-plugins/effects/thorns.js
+++ b/common/cards/card-plugins/effects/thorns.js
@@ -1,8 +1,8 @@
 import {AttackModel} from '../../../../server/models/attack-model'
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
-import {getCardPos} from '../../../../server/utils/cards'
 
 class ThornsEffectCard extends EffectCard {
 	constructor() {
@@ -19,7 +19,7 @@ class ThornsEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {opponentPlayer} = pos
@@ -47,7 +47,7 @@ class ThornsEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		delete pos.opponentPlayer.hooks.onAttack[instance]

--- a/common/cards/card-plugins/effects/thorns_ii.js
+++ b/common/cards/card-plugins/effects/thorns_ii.js
@@ -1,8 +1,8 @@
 import {AttackModel} from '../../../../server/models/attack-model'
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
-import {getCardPos} from '../../../../server/utils/cards'
 
 class ThornsIIEffectCard extends EffectCard {
 	constructor() {
@@ -19,7 +19,7 @@ class ThornsIIEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {opponentPlayer} = pos
@@ -48,7 +48,7 @@ class ThornsIIEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		delete pos.opponentPlayer.hooks.onAttack[instance]

--- a/common/cards/card-plugins/effects/thorns_iii.js
+++ b/common/cards/card-plugins/effects/thorns_iii.js
@@ -1,8 +1,8 @@
 import {AttackModel} from '../../../../server/models/attack-model'
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
-import {getCardPos} from '../../../../server/utils/cards'
 
 class ThornsIIIEffectCard extends EffectCard {
 	constructor() {
@@ -19,7 +19,7 @@ class ThornsIIIEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {opponentPlayer} = pos
@@ -48,7 +48,7 @@ class ThornsIIIEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		delete pos.opponentPlayer.hooks.onAttack[instance]

--- a/common/cards/card-plugins/effects/totem.js
+++ b/common/cards/card-plugins/effects/totem.js
@@ -1,5 +1,6 @@
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {discardCard} from '../../../../server/utils'
 import {isTargetingPos} from '../../../../server/utils/attacks'
 
@@ -17,7 +18,7 @@ class TotemEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -40,7 +41,7 @@ class TotemEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		delete pos.player.hooks.afterDefence[instance]

--- a/common/cards/card-plugins/effects/turtle-shell.js
+++ b/common/cards/card-plugins/effects/turtle-shell.js
@@ -1,6 +1,7 @@
 import EffectCard from './_effect-card'
 import {discardCard} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {isTargetingPos} from '../../../../server/utils/attacks'
 
 /*
@@ -42,12 +43,12 @@ class TurtleShellEffectCard extends EffectCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
 		const {currentPlayer} = game.ds
 
-		if (pos.slot.type !== 'effect') return 'INVALID'
+		if (!pos.slot || pos.slot.type !== 'effect') return 'INVALID'
 		if (pos.player.id !== currentPlayer.id) return 'INVALID'
 
 		if (!pos.row?.hermitCard) return 'NO'
@@ -61,7 +62,7 @@ class TurtleShellEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -96,7 +97,7 @@ class TurtleShellEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		delete pos.player.hooks.onDefence[instance]

--- a/common/cards/card-plugins/effects/water-bucket.js
+++ b/common/cards/card-plugins/effects/water-bucket.js
@@ -1,4 +1,5 @@
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {discardCard} from '../../../../server/utils'
 import EffectCard from './_effect-card'
 
@@ -18,10 +19,11 @@ class WaterBucketEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
-		const {player, opponentPlayer, slot, row} = pos
+		const {player, opponentPlayer, slot} = pos
+		if (!slot) return
 		if (slot.type === 'single_use') {
 			player.hooks.onApply[instance] = (pickedSlots, modalResult) => {
 				const pickedCards = pickedSlots[this.id] || []
@@ -41,13 +43,13 @@ class WaterBucketEffectCard extends EffectCard {
 			}
 		} else if (slot.type === 'effect') {
 			player.hooks.onDefence[instance] = (attack) => {
-				if (!row) return
-				row.ailments = row.ailments.filter((a) => a.id !== 'fire')
+				if (!pos.row) return
+				pos.row.ailments = pos.row.ailments.filter((a) => a.id !== 'fire')
 			}
 
 			opponentPlayer.hooks.afterApply[instance] = (pickedSlots, modalResult) => {
-				if (!row) return
-				row.ailments = row.ailments.filter((a) => a.id !== 'fire')
+				if (!pos.row) return
+				pos.row.ailments = pos.row.ailments.filter((a) => a.id !== 'fire')
 			}
 		}
 	}
@@ -55,7 +57,7 @@ class WaterBucketEffectCard extends EffectCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -66,9 +68,10 @@ class WaterBucketEffectCard extends EffectCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
+		if (!pos.slot) return 'INVALID'
 		if (!['single_use', 'effect'].includes(pos.slot.type)) return 'INVALID'
 		if (!pos.row?.hermitCard && pos.slot.type === 'effect') return 'NO'
 

--- a/common/cards/card-plugins/effects/wolf.js
+++ b/common/cards/card-plugins/effects/wolf.js
@@ -1,6 +1,7 @@
 import {AttackModel} from '../../../../server/models/attack-model'
 import EffectCard from './_effect-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {getCardPos} from '../../../../server/utils/cards'
 import {isTargetingPos} from '../../../../server/utils/attacks'
 import {getActiveRowPos} from '../../../../server/utils'
@@ -20,7 +21,7 @@ class WolfEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -65,7 +66,7 @@ class WolfEffectCard extends EffectCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player, opponentPlayer} = pos

--- a/common/cards/card-plugins/hermits/_hermit-card.js
+++ b/common/cards/card-plugins/hermits/_hermit-card.js
@@ -1,6 +1,6 @@
 import {AttackModel} from '../../../../server/models/attack-model'
 import {GameModel} from '../../../../server/models/game-model'
-import {getCardPos} from '../../../../server/utils/cards'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {createWeaknessAttack} from '../../../../server/utils/attacks'
 import Card from '../_card'
 
@@ -45,7 +45,7 @@ class HermitCard extends Card {
 	 * Creates and returns attack objects
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 * @param {import('../../../types/attack').HermitAttackType} hermitAttackType
 	 * @param {import('../../../types/pick-process').PickedSlots} pickedSlots
 	 * @returns {Array<AttackModel>}
@@ -94,12 +94,12 @@ class HermitCard extends Card {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
 		const {currentPlayer} = game.ds
 
-		if (pos.slot.type !== 'hermit') return 'INVALID'
+		if (!pos.slot || pos.slot.type !== 'hermit') return 'INVALID'
 		if (pos.player.id !== currentPlayer.id) return 'INVALID'
 
 		return 'YES'

--- a/common/cards/card-plugins/hermits/bdoubleo100-rare.js
+++ b/common/cards/card-plugins/hermits/bdoubleo100-rare.js
@@ -1,6 +1,6 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
-import {getCardPos} from '../../../../server/utils/cards'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {HERMIT_CARDS} from '../..'
 
 class BdoubleO100RareHermitCard extends HermitCard {
@@ -30,7 +30,7 @@ class BdoubleO100RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -56,7 +56,7 @@ class BdoubleO100RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/cubfan135-rare.js
+++ b/common/cards/card-plugins/hermits/cubfan135-rare.js
@@ -1,5 +1,6 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class Cubfan135RareHermitCard extends HermitCard {
 	constructor() {
@@ -27,7 +28,7 @@ class Cubfan135RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -70,7 +71,7 @@ class Cubfan135RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/docm77-rare.js
+++ b/common/cards/card-plugins/hermits/docm77-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class Docm77RareHermitCard extends HermitCard {
 	constructor() {
@@ -29,7 +30,7 @@ class Docm77RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -51,7 +52,7 @@ class Docm77RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/ethoslab-rare.js
+++ b/common/cards/card-plugins/hermits/ethoslab-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class EthosLabRareHermitCard extends HermitCard {
 	constructor() {
@@ -29,19 +30,14 @@ class EthosLabRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
 
 		player.hooks.onAttack[instance] = (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (
-				attack.id !== attackId ||
-				attack.type !== 'secondary' ||
-				!attack.target
-			)
-				return
+			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.target) return
 
 			const coinFlip = flipCoin(player, this.id)
 
@@ -59,7 +55,7 @@ class EthosLabRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/ethoslab-ultra-rare.js
+++ b/common/cards/card-plugins/hermits/ethoslab-ultra-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class EthosLabUltraRareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +29,7 @@ class EthosLabUltraRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -46,7 +47,7 @@ class EthosLabUltraRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/evilxisuma_rare.js
+++ b/common/cards/card-plugins/hermits/evilxisuma_rare.js
@@ -1,10 +1,7 @@
 import {flipCoin} from '../../../../server/utils'
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
-
-/**
- * @typedef {import('../../../types/cards').CardPos} CardPos
- */
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class EvilXisumaRareHermitCard extends HermitCard {
 	constructor() {

--- a/common/cards/card-plugins/hermits/falsesymmetry-rare.js
+++ b/common/cards/card-plugins/hermits/falsesymmetry-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {HERMIT_CARDS} from '../..'
 
 class FalseSymmetryRareHermitCard extends HermitCard {
@@ -29,7 +30,7 @@ class FalseSymmetryRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -53,7 +54,7 @@ class FalseSymmetryRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/geminitay-rare.js
+++ b/common/cards/card-plugins/hermits/geminitay-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {discardSingleUse} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 // Because of this card we can't rely elsewhere on the suCard to be in state on turnEnd hook
 class GeminiTayRareHermitCard extends HermitCard {
@@ -29,7 +30,7 @@ class GeminiTayRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -87,7 +88,7 @@ class GeminiTayRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/goatfather-rare.js
+++ b/common/cards/card-plugins/hermits/goatfather-rare.js
@@ -1,10 +1,10 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {flipCoin} from '../../../../server/utils'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/attack').HermitAttackType} HermitAttackType
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */

--- a/common/cards/card-plugins/hermits/goodtimeswithscar-rare.js
+++ b/common/cards/card-plugins/hermits/goodtimeswithscar-rare.js
@@ -1,5 +1,6 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class GoodTimesWithScarRareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +29,7 @@ class GoodTimesWithScarRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer, row} = pos
@@ -59,7 +60,7 @@ class GoodTimesWithScarRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player, opponentPlayer} = pos

--- a/common/cards/card-plugins/hermits/grian-rare.js
+++ b/common/cards/card-plugins/hermits/grian-rare.js
@@ -2,6 +2,7 @@ import HermitCard from './_hermit-card'
 import {discardCard, flipCoin, isRemovable} from '../../../../server/utils'
 import {swapSlots} from '../../../../server/utils/slots'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {getCardPos} from '../../../../server/utils/cards'
 
 // The tricky part about this one are destroyable items (shield, totem, loyalty) since they are available at the moment of attack, but not after
@@ -15,7 +16,6 @@ Some assumptions that make sense to me:
 */
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/cards').SlotPos} SlotPos
  */
 
@@ -71,11 +71,7 @@ class GrianRareHermitCard extends HermitCard {
 		}
 
 		// We need to wait until Loyalty disappear, it uses onHermitDeath
-		player.hooks.onFollowUp[instance] = (
-			followUp,
-			pickedCards,
-			modalResult
-		) => {
+		player.hooks.onFollowUp[instance] = (followUp, pickedCards, modalResult) => {
 			if (followUp === instanceKey) {
 				delete player.followUp[instanceKey]
 				const targetInstance = player.custom[targetKey]

--- a/common/cards/card-plugins/hermits/helsknight-rare.js
+++ b/common/cards/card-plugins/hermits/helsknight-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {moveCardToHand} from '../../../../server/utils'
 
 class HelsknightRareHermitCard extends HermitCard {
@@ -30,7 +31,7 @@ class HelsknightRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -58,7 +59,7 @@ class HelsknightRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/hotguy-rare.js
+++ b/common/cards/card-plugins/hermits/hotguy-rare.js
@@ -1,9 +1,9 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {SINGLE_USE_CARDS} from '../../../../common/cards'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/attack').HermitAttackType} HermitAttackType
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */

--- a/common/cards/card-plugins/hermits/humancleo-rare.js
+++ b/common/cards/card-plugins/hermits/humancleo-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {HERMIT_CARDS, ITEM_CARDS} from '../..'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {flipCoin} from '../../../../server/utils'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {getNonEmptyRows, hasEnoughEnergy, getActiveRowPos} from '../../../../server/utils'
@@ -36,7 +37,7 @@ class HumanCleoRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -190,7 +191,7 @@ class HumanCleoRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player, opponentPlayer} = pos

--- a/common/cards/card-plugins/hermits/hypnotizd-rare.js
+++ b/common/cards/card-plugins/hermits/hypnotizd-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {discardCard} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {createWeaknessAttack} from '../../../../server/utils/attacks'
 
 /*
@@ -45,7 +46,7 @@ class HypnotizdRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 * @param {import('types/attack').HermitAttackType} hermitAttackType
 	 * @param {import('types/pick-process').PickedSlots} pickedSlots
 	 */

--- a/common/cards/card-plugins/hermits/ijevin-rare.js
+++ b/common/cards/card-plugins/hermits/ijevin-rare.js
@@ -1,10 +1,7 @@
 import HermitCard from './_hermit-card'
 import {getNonEmptyRows} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class IJevinRareHermitCard extends HermitCard {
 	constructor() {

--- a/common/cards/card-plugins/hermits/impulsesv-rare.js
+++ b/common/cards/card-plugins/hermits/impulsesv-rare.js
@@ -1,5 +1,6 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class ImpulseSVRareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +29,7 @@ class ImpulseSVRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('common/types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -51,7 +52,7 @@ class ImpulseSVRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('common/types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/iskall85-rare.js
+++ b/common/cards/card-plugins/hermits/iskall85-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {HERMIT_CARDS} from '../../../cards'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class Iskall85RareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +29,7 @@ class Iskall85RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -50,7 +51,7 @@ class Iskall85RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/jingler-rare.js
+++ b/common/cards/card-plugins/hermits/jingler-rare.js
@@ -1,10 +1,7 @@
 import HermitCard from './_hermit-card'
 import {discardCard, flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class JinglerRareHermitCard extends HermitCard {
 	constructor() {

--- a/common/cards/card-plugins/hermits/joehills-rare.js
+++ b/common/cards/card-plugins/hermits/joehills-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/game-state').AvailableActionsT} AvailableActionsT
@@ -32,7 +33,7 @@ class JoeHillsRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('common/types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -106,7 +107,7 @@ class JoeHillsRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player, opponentPlayer} = pos

--- a/common/cards/card-plugins/hermits/keralis-rare.js
+++ b/common/cards/card-plugins/hermits/keralis-rare.js
@@ -1,5 +1,6 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {HERMIT_CARDS} from '../..'
 
 class KeralisRareHermitCard extends HermitCard {
@@ -30,7 +31,7 @@ class KeralisRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -60,7 +61,7 @@ class KeralisRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		delete pos.player.hooks.onAttack[instance]

--- a/common/cards/card-plugins/hermits/llamadad-rare.js
+++ b/common/cards/card-plugins/hermits/llamadad-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class LlamadadRareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +29,7 @@ class LlamadadRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -46,7 +47,7 @@ class LlamadadRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/mumbojumbo-rare.js
+++ b/common/cards/card-plugins/hermits/mumbojumbo-rare.js
@@ -2,6 +2,7 @@ import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {HERMIT_CARDS} from '../../../cards'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /*
 - Beef confirmed that double damage condition includes other rare mumbos.
@@ -33,7 +34,7 @@ class MumboJumboRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -58,7 +59,7 @@ class MumboJumboRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/pearlescentmoon-rare.js
+++ b/common/cards/card-plugins/hermits/pearlescentmoon-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 // TODO - Prevent consecutive use
 class PearlescentMoonRareHermitCard extends HermitCard {
@@ -30,7 +31,7 @@ class PearlescentMoonRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -81,7 +82,7 @@ class PearlescentMoonRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player, opponentPlayer} = pos

--- a/common/cards/card-plugins/hermits/potatoboy-rare.js
+++ b/common/cards/card-plugins/hermits/potatoboy-rare.js
@@ -1,7 +1,7 @@
 import HermitCard from './_hermit-card'
 import {HERMIT_CARDS} from '../../../cards'
 import {GameModel} from '../../../../server/models/game-model'
-import {AttackModel} from '../../../../server/models/attack-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class PotatoBoyRareHermitCard extends HermitCard {
 	constructor() {
@@ -29,7 +29,7 @@ class PotatoBoyRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -56,7 +56,7 @@ class PotatoBoyRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/renbob-rare.js
+++ b/common/cards/card-plugins/hermits/renbob-rare.js
@@ -1,5 +1,6 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {createWeaknessAttack} from '../../../../server/utils/attacks'
 
@@ -31,7 +32,7 @@ class RenbobRareHermitCard extends HermitCard {
 	 * Creates and returns attack objects
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 * @param {import('../../../types/attack').HermitAttackType} hermitAttackType
 	 * @param {import('../../../types/pick-process').PickedSlots} pickedSlots
 	 * @returns {Array<AttackModel>}

--- a/common/cards/card-plugins/hermits/rendog-rare.js
+++ b/common/cards/card-plugins/hermits/rendog-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {HERMIT_CARDS} from '../../../cards'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class RendogRareHermitCard extends HermitCard {
 	constructor() {
@@ -30,7 +31,7 @@ class RendogRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 * @param {import('types/attack').HermitAttackType} hermitAttackType
 	 * @param {import('types/pick-process').PickedSlots} pickedSlots
 	 */
@@ -65,7 +66,7 @@ class RendogRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -88,7 +89,7 @@ class RendogRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/stressmonster101-rare.js
+++ b/common/cards/card-plugins/hermits/stressmonster101-rare.js
@@ -1,5 +1,6 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 
 class StressMonster101RareHermitCard extends HermitCard {
@@ -28,7 +29,7 @@ class StressMonster101RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('common/types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -55,7 +56,7 @@ class StressMonster101RareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('common/types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/tangotek-rare.js
+++ b/common/cards/card-plugins/hermits/tangotek-rare.js
@@ -1,10 +1,7 @@
 import HermitCard from './_hermit-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {getNonEmptyRows, isActionAvailable} from '../../../../server/utils'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class TangoTekRareHermitCard extends HermitCard {
 	constructor() {

--- a/common/cards/card-plugins/hermits/tinfoilchef-rare.js
+++ b/common/cards/card-plugins/hermits/tinfoilchef-rare.js
@@ -1,8 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
-import {AttackModel} from '../../../../server/models/attack-model'
-import {getCardPos} from '../../../../server/utils/cards'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class TinFoilChefRareHermitCard extends HermitCard {
 	constructor() {
@@ -30,7 +29,7 @@ class TinFoilChefRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -50,7 +49,7 @@ class TinFoilChefRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/tinfoilchef-ultra-rare.js
+++ b/common/cards/card-plugins/hermits/tinfoilchef-ultra-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin, discardCard, isRemovable} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class TinFoilChefUltraRareHermitCard extends HermitCard {
 	constructor() {
@@ -29,7 +30,7 @@ class TinFoilChefUltraRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -59,7 +60,7 @@ class TinFoilChefUltraRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/vintagebeef-rare.js
+++ b/common/cards/card-plugins/hermits/vintagebeef-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class VintageBeefRareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +29,7 @@ class VintageBeefRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -51,7 +52,7 @@ class VintageBeefRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/vintagebeef-ultra-rare.js
+++ b/common/cards/card-plugins/hermits/vintagebeef-ultra-rare.js
@@ -1,6 +1,6 @@
 import HermitCard from './_hermit-card'
-import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class VintageBeefUltraRareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +28,7 @@ class VintageBeefUltraRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -52,7 +52,7 @@ class VintageBeefUltraRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/welsknight-rare.js
+++ b/common/cards/card-plugins/hermits/welsknight-rare.js
@@ -1,6 +1,6 @@
 import HermitCard from './_hermit-card'
-import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class WelsknightRareHermitCard extends HermitCard {
 	constructor() {
@@ -28,7 +28,7 @@ class WelsknightRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -47,7 +47,7 @@ class WelsknightRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/xbcrafted-rare.js
+++ b/common/cards/card-plugins/hermits/xbcrafted-rare.js
@@ -1,6 +1,6 @@
 import HermitCard from './_hermit-card'
-import CARDS from '../../../cards'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {getCardPos} from '../../../../server/utils/cards'
 
 /*
@@ -32,7 +32,7 @@ class XBCraftedRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 * @param {import('../../../types/attack').HermitAttackType} hermitAttackType
 	 * @param {import('../../../types/pick-process').PickedSlots} pickedSlots
 	 */
@@ -46,7 +46,7 @@ class XBCraftedRareHermitCard extends HermitCard {
 				if (!pos || !attacks[0].target) return false
 
 				const onTargetRow = pos.rowIndex === attacks[0].target.rowIndex
-				if (onTargetRow && pos.slot.type === 'effect') {
+				if (onTargetRow && pos.slot && pos.slot.type === 'effect') {
 					// It's the targets effect card, ignore it
 					return true
 				}

--- a/common/cards/card-plugins/hermits/xisumavoid-rare.js
+++ b/common/cards/card-plugins/hermits/xisumavoid-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class XisumavoidRareHermitCard extends HermitCard {
 	constructor() {
@@ -29,19 +30,14 @@ class XisumavoidRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
 
 		player.hooks.onAttack[instance] = (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (
-				attack.id !== attackId ||
-				attack.type !== 'secondary' ||
-				!attack.target
-			)
-				return
+			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.target) return
 
 			const coinFlip = flipCoin(player, this.id)
 			if (coinFlip[0] !== 'heads') return
@@ -58,7 +54,7 @@ class XisumavoidRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/zedaphplays-rare.js
+++ b/common/cards/card-plugins/hermits/zedaphplays-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class ZedaphPlaysRareHermitCard extends HermitCard {
 	constructor() {
@@ -29,7 +30,7 @@ class ZedaphPlaysRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -71,7 +72,7 @@ class ZedaphPlaysRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/hermits/zombiecleo-rare.js
+++ b/common/cards/card-plugins/hermits/zombiecleo-rare.js
@@ -1,6 +1,7 @@
 import HermitCard from './_hermit-card'
 import {HERMIT_CARDS} from '../../../cards'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {getNonEmptyRows} from '../../../../server/utils'
 
 /**
@@ -35,7 +36,7 @@ class ZombieCleoRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 * @param {import('types/attack').HermitAttackType} hermitAttackType
 	 * @param {import('types/pick-process').PickedSlots} pickedSlots
 	 */
@@ -63,7 +64,7 @@ class ZombieCleoRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -85,7 +86,7 @@ class ZombieCleoRareHermitCard extends HermitCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/items/_item-card.js
+++ b/common/cards/card-plugins/items/_item-card.js
@@ -1,4 +1,5 @@
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import Card from '../_card'
 
 class ItemCard extends Card {
@@ -23,12 +24,12 @@ class ItemCard extends Card {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
 		const {currentPlayer} = game.ds
 
-		if (pos.slot.type !== 'item') return 'INVALID'
+		if (!pos.slot || pos.slot.type !== 'item') return 'INVALID'
 		if (pos.player.id !== currentPlayer.id) return 'INVALID'
 
 		// Can't attach without hermit
@@ -40,7 +41,7 @@ class ItemCard extends Card {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 * @returns {Array<import('types/cards').EnergyT>}
 	 */
 	getEnergy(game, instance, pos) {

--- a/common/cards/card-plugins/single-use/_single-use-card.js
+++ b/common/cards/card-plugins/single-use/_single-use-card.js
@@ -1,10 +1,10 @@
 import {AttackModel} from '../../../../server/models/attack-model'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import Card from '../_card'
 
 /**
  * @typedef {import('../../../types/cards').SingleUseDefs} SingleUseDefs
- * @typedef {import('../../../types/cards').CardPos} CardPos
  * @typedef {import('../../../types/pick-process').PickedSlots} PickedSlots
  */
 
@@ -35,7 +35,7 @@ class SingleUseCard extends Card {
 	 * @returns {"YES" | "NO" | "INVALID"}
 	 */
 	canAttach(game, pos) {
-		if (pos.slot.type !== 'single_use') return 'INVALID'
+		if (!pos.slot || pos.slot.type !== 'single_use') return 'INVALID'
 
 		return 'YES'
 	}

--- a/common/cards/card-plugins/single-use/anvil.js
+++ b/common/cards/card-plugins/single-use/anvil.js
@@ -1,11 +1,8 @@
 import SingleUseCard from './_single-use-card'
 import {applySingleUse, getActiveRowPos} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class AnvilSingleUseCard extends SingleUseCard {
 	constructor() {

--- a/common/cards/card-plugins/single-use/bad-omen.js
+++ b/common/cards/card-plugins/single-use/bad-omen.js
@@ -1,9 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class BadOmenSingleUseCard extends SingleUseCard {

--- a/common/cards/card-plugins/single-use/bow.js
+++ b/common/cards/card-plugins/single-use/bow.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {applySingleUse, getActiveRowPos, getNonEmptyRows} from '../../../../server/utils'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 

--- a/common/cards/card-plugins/single-use/chest.js
+++ b/common/cards/card-plugins/single-use/chest.js
@@ -1,9 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {equalCard, retrieveCard} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 

--- a/common/cards/card-plugins/single-use/chorus-fruit.js
+++ b/common/cards/card-plugins/single-use/chorus-fruit.js
@@ -1,10 +1,7 @@
 import SingleUseCard from './_single-use-card'
 import {applySingleUse, getActiveRow} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class ChorusFruitSingleUseCard extends SingleUseCard {
 	constructor() {

--- a/common/cards/card-plugins/single-use/clock.js
+++ b/common/cards/card-plugins/single-use/clock.js
@@ -1,8 +1,8 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/game-state').AvailableActionsT} AvailableActionsT'
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */

--- a/common/cards/card-plugins/single-use/composter.js
+++ b/common/cards/card-plugins/single-use/composter.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {equalCard, discardCard, drawCards} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class ComposterSingleUseCard extends SingleUseCard {

--- a/common/cards/card-plugins/single-use/crossbow.js
+++ b/common/cards/card-plugins/single-use/crossbow.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {applySingleUse, getActiveRowPos} from '../../../../server/utils'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 

--- a/common/cards/card-plugins/single-use/curse-of-binding.js
+++ b/common/cards/card-plugins/single-use/curse-of-binding.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class CurseOfBindingSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -18,7 +19,7 @@ class CurseOfBindingSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {opponentPlayer, player} = pos
@@ -48,7 +49,7 @@ class CurseOfBindingSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/curse-of-vanishing.js
+++ b/common/cards/card-plugins/single-use/curse-of-vanishing.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {discardCard, isActive, isRemovable} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class CurseOfVanishingSingleUseCard extends SingleUseCard {

--- a/common/cards/card-plugins/single-use/diamond-sword.js
+++ b/common/cards/card-plugins/single-use/diamond-sword.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {applySingleUse, getActiveRowPos} from '../../../../server/utils'
 
@@ -16,7 +17,7 @@ class DiamondSwordSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -56,7 +57,7 @@ class DiamondSwordSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/efficiency.js
+++ b/common/cards/card-plugins/single-use/efficiency.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class EfficiencySingleUseCard extends SingleUseCard {
 	constructor() {
@@ -19,7 +20,7 @@ class EfficiencySingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -47,7 +48,7 @@ class EfficiencySingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/egg.js
+++ b/common/cards/card-plugins/single-use/egg.js
@@ -2,11 +2,8 @@ import SingleUseCard from './_single-use-card'
 import {flipCoin, getActiveRowPos, getNonEmptyRows} from '../../../../server/utils'
 import {applySingleUse} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class EggSingleUseCard extends SingleUseCard {
 	constructor() {

--- a/common/cards/card-plugins/single-use/emerald.js
+++ b/common/cards/card-plugins/single-use/emerald.js
@@ -2,9 +2,9 @@ import SingleUseCard from './_single-use-card'
 import {isRemovable} from '../../../../server/utils'
 import {swapSlots} from '../../../../server/utils/slots'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/cards').SlotPos} SlotPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
@@ -92,7 +92,7 @@ class EmeraldSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/ender-pearl.js
+++ b/common/cards/card-plugins/single-use/ender-pearl.js
@@ -1,9 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class EnderPearlSingleUseCard extends SingleUseCard {
@@ -60,7 +60,7 @@ class EnderPearlSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/fire-charge.js
+++ b/common/cards/card-plugins/single-use/fire-charge.js
@@ -1,11 +1,11 @@
 import {discardCard, discardSingleUse, rowHasItem, isRemovable} from '../../../../server/utils'
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import CARDS from '../../../cards'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class FireChargeSingleUseCard extends SingleUseCard {

--- a/common/cards/card-plugins/single-use/fishing-rod.js
+++ b/common/cards/card-plugins/single-use/fishing-rod.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {drawCards} from '../../../../server/utils'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class FishingRodSingleUseCard extends SingleUseCard {
@@ -49,7 +49,7 @@ class FishingRodSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/flint-and-steel.js
+++ b/common/cards/card-plugins/single-use/flint-and-steel.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {discardCard, drawCards} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class FlintAndSteelSingleUseCard extends SingleUseCard {
@@ -54,7 +54,7 @@ class FlintAndSteelSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/fortune.js
+++ b/common/cards/card-plugins/single-use/fortune.js
@@ -1,10 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
-import {applySingleUse} from '../../../../server/utils'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 // We could stop displaying the coin flips but I think it may confuse players when Zedaph or Pearl uses fortune.

--- a/common/cards/card-plugins/single-use/golden-apple.js
+++ b/common/cards/card-plugins/single-use/golden-apple.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {HERMIT_CARDS} from '../..'
 import {getNonEmptyRows, isActive} from '../../../../server/utils'
 
@@ -18,7 +19,7 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -38,7 +39,7 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
 		if (super.canAttach(game, pos) === 'INVALID') return 'INVALID'
@@ -57,7 +58,7 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/golden-axe.js
+++ b/common/cards/card-plugins/single-use/golden-axe.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {
 	applySingleUse,
@@ -8,10 +9,6 @@ import {
 	getActiveRowPos,
 } from '../../../../server/utils'
 import {getCardPos} from '../../../../server/utils/cards'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class GoldenAxeSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -61,7 +58,7 @@ class GoldenAxeSingleUseCard extends SingleUseCard {
 				if (!pos || !attack.target) return false
 
 				const onTargetRow = pos.rowIndex === attack.target.rowIndex
-				if (onTargetRow && pos.slot.type === 'effect') {
+				if (onTargetRow && pos.slot && pos.slot.type === 'effect') {
 					// It's the targets effect card, ignore it
 					return true
 				}

--- a/common/cards/card-plugins/single-use/instant-health-ii.js
+++ b/common/cards/card-plugins/single-use/instant-health-ii.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {HERMIT_CARDS} from '../..'
 
 class InstantHealthIISingleUseCard extends SingleUseCard {
@@ -17,7 +18,7 @@ class InstantHealthIISingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -38,7 +39,7 @@ class InstantHealthIISingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/instant-health.js
+++ b/common/cards/card-plugins/single-use/instant-health.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {HERMIT_CARDS} from '../..'
 
 class InstantHealthSingleUseCard extends SingleUseCard {
@@ -17,7 +18,7 @@ class InstantHealthSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -38,7 +39,7 @@ class InstantHealthSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/invisibility-potion.js
+++ b/common/cards/card-plugins/single-use/invisibility-potion.js
@@ -1,6 +1,7 @@
 import SingleUseCard from './_single-use-card'
 import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class InvisibilityPotionSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -20,7 +21,7 @@ class InvisibilityPotionSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -44,7 +45,7 @@ class InvisibilityPotionSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/iron-sword.js
+++ b/common/cards/card-plugins/single-use/iron-sword.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {applySingleUse, getActiveRowPos} from '../../../../server/utils'
 
@@ -16,7 +17,7 @@ class IronSwordSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -49,7 +50,7 @@ class IronSwordSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/knockback.js
+++ b/common/cards/card-plugins/single-use/knockback.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {applySingleUse, getActiveRow, getNonEmptyRows} from '../../../../server/utils'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  */
 
 class KnockbackSingleUseCard extends SingleUseCard {

--- a/common/cards/card-plugins/single-use/ladder.js
+++ b/common/cards/card-plugins/single-use/ladder.js
@@ -1,10 +1,10 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {swapSlots} from '../../../../server/utils/slots'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/cards').SlotPos} SlotPos
  */
 
@@ -97,7 +97,7 @@ class LadderSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/lava-bucket.js
+++ b/common/cards/card-plugins/single-use/lava-bucket.js
@@ -1,6 +1,6 @@
 import SingleUseCard from './_single-use-card'
-import {discardCard} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class LavaBucketSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -21,7 +21,7 @@ class LavaBucketSingleUseCard extends SingleUseCard {
 	 * Called when an instance of this card is applied
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -45,10 +45,10 @@ class LavaBucketSingleUseCard extends SingleUseCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
-		if (pos.slot.type !== 'single_use') return 'INVALID'
+		if (!pos.slot || pos.slot.type !== 'single_use') return 'INVALID'
 
 		if (pos.opponentPlayer.board.activeRow === null) return 'NO'
 
@@ -58,7 +58,7 @@ class LavaBucketSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/lead.js
+++ b/common/cards/card-plugins/single-use/lead.js
@@ -2,9 +2,9 @@ import SingleUseCard from './_single-use-card'
 import {rowHasItem, getRowsWithEmptyItemsSlots} from '../../../../server/utils'
 import {swapSlots} from '../../../../server/utils/slots'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/cards').SlotPos} SlotPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
@@ -89,7 +89,7 @@ class LeadSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/looting.js
+++ b/common/cards/card-plugins/single-use/looting.js
@@ -1,10 +1,6 @@
 import SingleUseCard from './_single-use-card'
-import {flipCoin} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class LootingSingleUseCard extends SingleUseCard {
 	constructor() {

--- a/common/cards/card-plugins/single-use/mending.js
+++ b/common/cards/card-plugins/single-use/mending.js
@@ -1,5 +1,6 @@
 import singleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {swapSlots} from '../../../../server/utils/slots'
 import {getNonEmptyRows, isRemovable} from '../../../../server/utils'
 
@@ -30,7 +31,7 @@ class MendingSingleUseCard extends singleUseCard {
 	 *
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player} = pos
@@ -71,7 +72,7 @@ class MendingSingleUseCard extends singleUseCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
 		if (super.canAttach(game, pos) === 'INVALID') return 'INVALID'
@@ -96,7 +97,7 @@ class MendingSingleUseCard extends singleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/netherite-sword.js
+++ b/common/cards/card-plugins/single-use/netherite-sword.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {applySingleUse, getActiveRowPos} from '../../../../server/utils'
 import {AttackModel} from '../../../../server/models/attack-model'
 
@@ -16,7 +17,7 @@ class NetheriteSwordSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -49,7 +50,7 @@ class NetheriteSwordSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/piston.js
+++ b/common/cards/card-plugins/single-use/piston.js
@@ -6,11 +6,11 @@ import {
 	rowHasItem,
 } from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {swapSlots} from '../../../../server/utils/slots'
 
 /**
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/cards').SlotPos} SlotPos
  */
 

--- a/common/cards/card-plugins/single-use/potion-of-slowness.js
+++ b/common/cards/card-plugins/single-use/potion-of-slowness.js
@@ -1,10 +1,7 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {getActiveRow} from '../../../../server/utils'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class PotionOfSlownessSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -38,7 +35,7 @@ class PotionOfSlownessSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/potion-of-weakness.js
+++ b/common/cards/card-plugins/single-use/potion-of-weakness.js
@@ -1,10 +1,7 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {getActiveRow} from '../../../../server/utils'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class PotionOfWeaknessSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -39,7 +36,7 @@ class PotionOfWeaknessSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/splash-potion-of-healing-ii.js
+++ b/common/cards/card-plugins/single-use/splash-potion-of-healing-ii.js
@@ -1,9 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {HERMIT_CARDS} from '../../index'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 
@@ -42,7 +42,7 @@ class SplashPotionOfHealingIISingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/splash-potion-of-healing.js
+++ b/common/cards/card-plugins/single-use/splash-potion-of-healing.js
@@ -1,9 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {HERMIT_CARDS} from '../../index'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 
@@ -42,7 +42,7 @@ class SplashPotionOfHealingSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/splash-potion-of-poison.js
+++ b/common/cards/card-plugins/single-use/splash-potion-of-poison.js
@@ -1,6 +1,7 @@
 import SingleUseCard from './_single-use-card'
 import {discardCard} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 class SplashPotionOfPoisonSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -21,7 +22,7 @@ class SplashPotionOfPoisonSingleUseCard extends SingleUseCard {
 	 * Called when an instance of this card is applied
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -45,10 +46,10 @@ class SplashPotionOfPoisonSingleUseCard extends SingleUseCard {
 
 	/**
 	 * @param {GameModel} game
-	 * @param {import('../../../types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	canAttach(game, pos) {
-		if (pos.slot.type !== 'single_use') return 'INVALID'
+		if (!pos.slot || pos.slot.type !== 'single_use') return 'INVALID'
 
 		if (pos.opponentPlayer.board.activeRow === null) return 'NO'
 
@@ -58,7 +59,7 @@ class SplashPotionOfPoisonSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/spyglass.js
+++ b/common/cards/card-plugins/single-use/spyglass.js
@@ -1,9 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {discardCard, flipCoin} from '../../../../server/utils'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 

--- a/common/cards/card-plugins/single-use/sweeping-edge.js
+++ b/common/cards/card-plugins/single-use/sweeping-edge.js
@@ -1,9 +1,9 @@
 import SingleUseCard from './_single-use-card'
 import {discardCard, isRemovable} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 
@@ -73,7 +73,7 @@ class SweepingEdgeSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/target-block.js
+++ b/common/cards/card-plugins/single-use/target-block.js
@@ -1,10 +1,10 @@
 import {getNonEmptyRows} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {createWeaknessAttack} from '../../../../server/utils/attacks'
 import SingleUseCard from './_single-use-card'
 
 /**
- * @typedef {import('common/types/cards').CardPos} CardPos
  * @typedef {import('common/types/pick-process').PickedSlots} PickedSlots
  */
 

--- a/common/cards/card-plugins/single-use/tnt.js
+++ b/common/cards/card-plugins/single-use/tnt.js
@@ -1,5 +1,6 @@
 import SingleUseCard from './_single-use-card'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
 import {applySingleUse, getActiveRowPos} from '../../../../server/utils'
 
@@ -16,7 +17,7 @@ class TNTSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onAttach(game, instance, pos) {
 		const {player, opponentPlayer} = pos
@@ -59,7 +60,7 @@ class TNTSingleUseCard extends SingleUseCard {
 	/**
 	 * @param {GameModel} game
 	 * @param {string} instance
-	 * @param {import('types/cards').CardPos} pos
+	 * @param {CardPos} pos
 	 */
 	onDetach(game, instance, pos) {
 		const {player} = pos

--- a/common/cards/card-plugins/single-use/trident.js
+++ b/common/cards/card-plugins/single-use/trident.js
@@ -1,11 +1,8 @@
 import SingleUseCard from './_single-use-card'
 import {flipCoin, applySingleUse, discardSingleUse, getActiveRowPos} from '../../../../server/utils'
 import {GameModel} from '../../../../server/models/game-model'
+import {CardPos} from '../../../../server/models/card-pos-model'
 import {AttackModel} from '../../../../server/models/attack-model'
-
-/**
- * @typedef {import('common/types/cards').CardPos} CardPos
- */
 
 class TridentSingleUseCard extends SingleUseCard {
 	constructor() {

--- a/common/types/cards.ts
+++ b/common/types/cards.ts
@@ -95,13 +95,6 @@ export type BoardSlot = {
 	index: number
 }
 
-export type CardPos = {
-	player: PlayerState
-	opponentPlayer: PlayerState
-	rowIndex: number | null
-	row: RowState | null
-	slot: Slot
-}
 
 export type RowPos = {
 	player: PlayerState

--- a/common/types/game-state.ts
+++ b/common/types/game-state.ts
@@ -1,6 +1,7 @@
 import {AttackModel} from '../../server/models/attack-model'
 import {GameModel} from '../../server/models/game-model'
-import {CardPos, EnergyT} from './cards'
+import {CardPos} from '../../server/models/card-pos-model'
+import {EnergyT} from './cards'
 import {MessageInfoT} from './chat'
 import {PickProcessT, PickedSlots} from './pick-process'
 

--- a/server/models/card-pos-model.js
+++ b/server/models/card-pos-model.js
@@ -1,0 +1,161 @@
+export class CardPos {
+	player
+	opponentPlayer
+	instance
+	/** @type {Number | null} */
+	#rowIndex
+	/** @type {import("types/cards").Slot} */
+	#slot
+
+	/**
+	 * @param {PlayerState} player
+	 * @param {PlayerState} opponentPlayer
+	 * @param {string | null} instance
+	 * @param {Number | null} rowIndex
+	 * @param {import("types/cards").Slot} slot
+	 */
+	constructor(player, opponentPlayer, instance, rowIndex, slot) {
+		this.player = player
+		this.opponentPlayer = opponentPlayer
+		this.instance = instance
+		this.#rowIndex = rowIndex
+		this.#slot = slot
+	}
+
+	/**
+	 * Checks if the instance is in the same position as the current one
+	 */
+	#checkInstancePos = () => {
+		// The card hasn't been attached yet
+		if (!this.instance) return true
+
+		const {board} = this.player
+		let card = null
+
+		if (this.#slot.type === 'single_use') {
+			card = board.singleUseCard
+		} else if (this.#rowIndex !== null) {
+			const row = board.rows[this.#rowIndex]
+			if (this.#slot.type === 'hermit') {
+				card = row.hermitCard
+			} else if (this.#slot.type === 'effect') {
+				card = row.effectCard
+			} else if (this.#slot.type === 'item') {
+				card = row.itemCards[this.#slot.index]
+			}
+		}
+
+		return card?.cardInstance === this.instance
+	}
+
+	/**
+	 * Searches for the instance on the board
+	 * We only search the current side of the board, if the card is on the opponent's side
+	 * then it should be reattached otherwise the hooks will be backwards
+	 * @returns {Boolean}
+	 */
+	#searchInstance = () => {
+		const board = this.player.board
+
+		if (board.singleUseCard?.cardInstance === this.instance) {
+			this.#rowIndex = null
+			this.#slot.type = 'single_use'
+			this.#slot.index = 0
+			return true
+		}
+
+		// Go through rows to find instance
+		for (let rowIndex = 0; rowIndex < board.rows.length; rowIndex++) {
+			const row = board.rows[rowIndex]
+
+			if (row.hermitCard?.cardInstance === this.instance) {
+				this.#rowIndex = rowIndex
+				this.#slot.type = 'hermit'
+				this.#slot.index = 0
+				return true
+			}
+
+			if (row.effectCard?.cardInstance === this.instance) {
+				this.#rowIndex = rowIndex
+				this.#slot.type = 'effect'
+				this.#slot.index = 0
+				return true
+			}
+
+			for (let i = 0; i < row.itemCards.length; i++) {
+				const card = row.itemCards[i]
+				if (card?.cardInstance === this.instance) {
+					this.#rowIndex = rowIndex
+					this.#slot.type = 'item'
+					this.#slot.index = i
+					return true
+				}
+			}
+		}
+
+		return false
+	}
+
+	/**
+	 * Gets the RowIndex
+	 * @returns {Number | null}
+	 */
+	get rowIndex() {
+		if (this.#slot && this.#slot.type === 'single_use') return null
+		if (!this.#checkInstancePos() && !this.#searchInstance()) {
+			return null
+		}
+		return this.#rowIndex
+	}
+
+	/**
+	 * Gets the RowState
+	 * @returns {RowState | null}
+	 */
+	get row() {
+		if (this.#slot.type === 'single_use') return null
+		if (!this.#rowIndex) return null
+		if (!this.#checkInstancePos() && !this.#searchInstance()) {
+			return null
+		}
+		return this.player.board.rows[this.#rowIndex]
+	}
+
+	/**
+	 * Gets the Slot
+	 * @returns {import("types/cards").Slot | null}
+	 */
+	get slot() {
+		if (!this.#checkInstancePos() && !this.#searchInstance()) {
+			return null
+		}
+		return this.#slot
+	}
+
+	/**
+	 * Gets the CardT from the current state.
+	 * @returns {CardT | null}
+	 */
+	get card() {
+		if (!this.#rowIndex) return null
+		// if the instance is not in the same position as the current one, search for it
+		if (!this.#checkInstancePos() && !this.#searchInstance()) {
+			return null
+		}
+
+		const row = this.player.board.rows[this.#rowIndex]
+		if (this.#slot.type === 'single_use') {
+			return this.player.board.singleUseCard
+		} else if (this.#slot.type === 'hermit') {
+			return row.hermitCard
+		} else if (this.#slot.type === 'effect') {
+			return row.effectCard
+		} else if (this.#slot.type === 'item') {
+			return row.itemCards[this.#slot.index]
+		}
+
+		return null
+	}
+}
+
+export default CardPos

--- a/server/models/card-pos-model.js
+++ b/server/models/card-pos-model.js
@@ -23,7 +23,8 @@ export class CardPos {
 	}
 
 	/**
-	 * Checks if the instance is in the same position as the current one
+	 * Checks if the instance is in the same position as before
+	 * @returns {Boolean}
 	 */
 	#checkInstancePos = () => {
 		// The card hasn't been attached yet

--- a/server/routines/turn-actions/attack.js
+++ b/server/routines/turn-actions/attack.js
@@ -2,6 +2,7 @@ import {HERMIT_CARDS, EFFECT_CARDS, SINGLE_USE_CARDS} from '../../../common/card
 import STRENGTHS from '../../const/strengths'
 import {AttackModel} from '../../models/attack-model'
 import {GameModel} from '../../models/game-model'
+import {CardPos} from '../../../server/models/card-pos-model'
 import {getCardPos} from '../../utils/cards'
 import {DEBUG_CONFIG} from '../../../config'
 
@@ -22,7 +23,7 @@ export const WEAKNESS_DAMAGE = 20
 /**
  *
  * @param {GameModel} game
- * @param {import('common/types/cards').CardPos} attackPos
+ * @param {CardPos} attackPos
  * @param {HermitAttackType} hermitAttackType
  * @param {import('common/types/pick-process').PickedSlots} pickedSlots
  * @returns {Array<AttackModel>}

--- a/server/utils/attacks.js
+++ b/server/utils/attacks.js
@@ -2,11 +2,12 @@ import STRENGTHS from '../const/strengths'
 import {HERMIT_CARDS} from '../../common/cards'
 import {AttackModel} from '../models/attack-model'
 import {WEAKNESS_DAMAGE} from '../routines/turn-actions/attack.js'
+import CardPos from '../../server/models/card-pos-model'
 
 /**
  * Returns true if the attack is targeting the card position
  * @param {import('../models/attack-model').AttackModel} attack
- * @param {import('types/cards').CardPos} pos
+ * @param {CardPos} pos
  * @returns {boolean}
  */
 export function isTargetingPos(attack, pos) {

--- a/server/utils/cards.js
+++ b/server/utils/cards.js
@@ -1,10 +1,11 @@
 import {GameModel} from '../models/game-model'
+import {CardPos} from '..//models/card-pos-model'
 
 /**
  * Get the card position on the board for a card instance
  * @param {GameModel} game
  * @param {string} instance
- * @returns {import("../../common/types/cards").CardPos | null}
+ * @returns {CardPos | null}
  */
 export function getCardPos(game, instance) {
 	const ids = game.getPlayerIds()
@@ -20,13 +21,10 @@ export function getCardPos(game, instance) {
 
 		// single use slot
 		if (board.singleUseCard?.cardInstance === instance) {
-			return {
-				player,
-				opponentPlayer,
-				rowIndex: null,
-				row: null,
-				slot: {type: 'single_use', index: 0},
-			}
+			return new CardPos(player, opponentPlayer, instance, null, {
+				type: 'single_use',
+				index: 0,
+			})
 		}
 
 		// go through rows to find instance
@@ -34,67 +32,27 @@ export function getCardPos(game, instance) {
 			const row = board.rows[rowIndex]
 
 			if (row.hermitCard?.cardInstance === instance) {
-				return {
-					player,
-					opponentPlayer,
-					rowIndex,
-					row,
-					slot: {type: 'hermit', index: 0},
-				}
+				return new CardPos(player, opponentPlayer, instance, rowIndex, {
+					type: 'hermit',
+					index: 0,
+				})
 			} else if (row.effectCard?.cardInstance === instance) {
-				return {
-					player,
-					opponentPlayer,
-					rowIndex,
-					row,
-					slot: {type: 'effect', index: 0},
-				}
+				return new CardPos(player, opponentPlayer, instance, rowIndex, {
+					type: 'effect',
+					index: 0,
+				})
 			} else {
 				for (let i = 0; i < row.itemCards.length; i++) {
 					const card = row.itemCards[i]
 					if (card?.cardInstance === instance) {
-						return {
-							player,
-							opponentPlayer,
-							rowIndex,
-							row,
-							slot: {type: 'item', index: i},
-						}
+						return new CardPos(player, opponentPlayer, instance, rowIndex, {
+							type: 'item',
+							index: i,
+						})
 					}
 				}
 			}
 		}
-	}
-
-	return null
-}
-
-/**
- * Get the card position on the board for a card instance
- * @param {GameModel} game
- * @param {import('../../common/types/cards').CardPos} pos
- * @returns {CardT | null}
- */
-export function getCardAtPos(game, pos) {
-	const {player, row, slot} = pos
-
-	const suCard = player.board.singleUseCard
-	if (slot.type === 'single_use' && suCard) {
-		return suCard
-	}
-
-	if (!row) return null
-
-	if (slot.type === 'hermit' && row.hermitCard) {
-		return row.hermitCard
-	}
-
-	if (slot.type === 'effect' && row.effectCard) {
-		return row.effectCard
-	}
-
-	if (slot.type === 'item' && row.itemCards[slot.index]) {
-		return row.itemCards[slot.index] || null
 	}
 
 	return null

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -95,7 +95,7 @@ export function applySingleUse(game, pickedSlots = {}, modalResult = null) {
 
 		for (const key of Object.keys(hook)) {
 			const cardPos = getCardPos(game, key)
-			if (cardPos && hooksByType[cardPos.slot.type]) {
+			if (cardPos && cardPos.slot && hooksByType[cardPos.slot.type]) {
 				hooksByType[cardPos.slot.type].push(hook[key])
 			} else {
 				// The card is no longer on the board, we can use the card type instead of the slot type
@@ -165,13 +165,13 @@ export function moveCardToHand(game, card, steal = false) {
 		onDetachs[i](card.cardInstance)
 	}
 
-	if (cardPos.row && cardPos.slot.type === 'hermit') {
+	if (cardPos.row && cardPos.slot?.type === 'hermit') {
 		cardPos.row.hermitCard = null
-	} else if (cardPos.row && cardPos.slot.type === 'effect') {
+	} else if (cardPos.row && cardPos.slot?.type === 'effect') {
 		cardPos.row.effectCard = null
-	} else if (cardPos.row && cardPos.slot.type === 'item') {
-		cardPos.row.itemCards[cardPos.slot.index] = null
-	} else if (cardPos.slot.type === 'single_use') {
+	} else if (cardPos.row && cardPos.slot?.type === 'item') {
+		cardPos.row.itemCards[cardPos.slot?.index] = null
+	} else if (cardPos.slot?.type === 'single_use') {
 		cardPos.player.board.singleUseCard = null
 	}
 


### PR DESCRIPTION
Fixes cards using the wrong position when moved by the Ladder/EnderPearl

Everything that was using pos.row, pos.rowIndex and pos.slot was broken after it was moved by those cards, this fixes it by updating them on the class if the position changed, detaching and attaching the cards again wasn't an option because they would lose their current state (custom/hooks).

Right now I'm sending the CardPos to canAttach without an instance and then setting it afterwards, otherwise it would trigger the check/search but the card won't be there so rowIndex, etc won't return anything even though the correct info was stored inside the class, basically what I did was to skip the instance check inside CardPos until the instance is set, we may want to consider using SlotPos (needs to be changed a bit) for canAttach instead.  
Also merging PickedSlotT and SlotPos may not be a bad idea, I just didn't have enough time and this was good enough for now.

Removed getCardAtPos, I'm storing the instance inside CardPos I can just give you the card using pos.card.

I tested a few cards with this but I don't have a lot of time right now, I would appreciate if someone can do a bit more testing, basically search whatever is using isTargetingPos/other helpers that use CardPos or anything that uses rowIndex/row inside the hooks (slot is not necessary because it won't change atm), those are the things that may break.

A few things to keep in mind.
- pos.slot can be null otherwise if for whatever reason the card can't be found there needs to be a way for whatever is using CardPos to know if it's using a valid position.
- You need to get rowIndex/row/slot inside the hooks otherwise you won't get the correct info after the card was moved, I changed the cards that were doing that.
