### PR TITLE
Fix typos in game descriptions

### DIFF
--- a/common/cards/card-plugins/effects/bed.js
+++ b/common/cards/card-plugins/effects/bed.js
@@ -10,7 +10,7 @@ class BedEffectCard extends EffectCard {
 			name: 'Bed',
 			rarity: 'ultra_rare',
 			description:
-				"Player sleeps for the rest of this and next 2 turns. Can't attack. Restores full health when bed is attached.\n\nCan still draw and attach cards while sleeping.\n\nMust be placed on active hermit.\n\nDiscard after player wakes up.\n\n\n\nCan not go afk while sleeping.\n\nIf made afk by opponent player, hermit goes afk but also wakes up.",
+				"Player sleeps for the rest of this and next 2 turns. Can't attack. Restores full health when bed is attached.\n\nCan still draw and attach cards while sleeping.\n\nMust be placed on active Hermit.\n\nDiscard after player wakes up.\n\n\n\nCan not go AFK while sleeping.\n\nIf made AFK by opponent player, Hermit goes AFK but also wakes up.",
 		})
 	}
 

--- a/common/cards/card-plugins/effects/thorns.js
+++ b/common/cards/card-plugins/effects/thorns.js
@@ -11,7 +11,7 @@ class ThornsEffectCard extends EffectCard {
 			name: 'Thorns',
 			rarity: 'common',
 			description:
-				'When the hermit this card is attached to takes damage, your opponent takes 20hp damage.\n\nIgnores armor.',
+				'When the Hermit this card is attached to takes damage, your opponent takes 20hp damage.\n\nIgnores armor.',
 		})
 	}
 

--- a/common/cards/card-plugins/effects/thorns_ii.js
+++ b/common/cards/card-plugins/effects/thorns_ii.js
@@ -11,7 +11,7 @@ class ThornsIIEffectCard extends EffectCard {
 			name: 'Thorns II',
 			rarity: 'rare',
 			description:
-				'When the hermit this card is attached to takes damage, your opponent takes 30hp damage.\n\nIgnores armor.',
+				'When the Hermit this card is attached to takes damage, your opponent takes 30hp damage.\n\nIgnores armor.',
 		})
 	}
 

--- a/common/cards/card-plugins/effects/thorns_iii.js
+++ b/common/cards/card-plugins/effects/thorns_iii.js
@@ -11,7 +11,7 @@ class ThornsIIIEffectCard extends EffectCard {
 			name: 'Thorns III',
 			rarity: 'ultra_rare',
 			description:
-				'When the hermit this card is attached to takes damage, your opponent takes 40hp damage.\n\nIgnores armor.',
+				'When the Hermit this card is attached to takes damage, your opponent takes 40hp damage.\n\nIgnores armor.',
 		})
 	}
 

--- a/common/cards/card-plugins/effects/wolf.js
+++ b/common/cards/card-plugins/effects/wolf.js
@@ -12,7 +12,7 @@ class WolfEffectCard extends EffectCard {
 			name: 'Wolf',
 			rarity: 'rare',
 			description:
-				"For every hermit attacked on your opponent's turn, your opponent's active hermit takes 10hp damage.",
+				"For every Hermit attacked on your opponent's turn, your opponent's active Hermit takes 10hp damage.",
 		})
 	}
 

--- a/common/cards/card-plugins/hermits/cubfan135-rare.js
+++ b/common/cards/card-plugins/hermits/cubfan135-rare.js
@@ -19,7 +19,7 @@ class Cubfan135RareHermitCard extends HermitCard {
 				name: "Let's Go",
 				cost: ['speedrunner', 'speedrunner', 'speedrunner'],
 				damage: 100,
-				power: 'After attack, you can choose to go afk.',
+				power: 'After attack, you can choose to go AFK.',
 			},
 		})
 	}

--- a/common/cards/card-plugins/hermits/rendog-rare.js
+++ b/common/cards/card-plugins/hermits/rendog-rare.js
@@ -20,7 +20,7 @@ class RendogRareHermitCard extends HermitCard {
 				name: 'Role Play',
 				cost: ['builder', 'builder', 'builder'],
 				damage: 0,
-				power: "Use any secondary move of your opponent's hermits.",
+				power: "Use any secondary move of your opponent's Hermits.",
 			},
 			pickOn: 'attack',
 			pickReqs: [{target: 'opponent', slot: ['hermit'], type: ['hermit'], amount: 1}],

--- a/common/cards/card-plugins/hermits/stressmonster101-rare.js
+++ b/common/cards/card-plugins/hermits/stressmonster101-rare.js
@@ -20,7 +20,7 @@ class StressMonster101RareHermitCard extends HermitCard {
 				name: 'Yolo',
 				cost: ['prankster', 'prankster', 'prankster'],
 				damage: 0,
-				power: 'You and opponent take damage equal to your health.',
+				power: 'You and your opponent take damage equal to your health.',
 			},
 		})
 	}

--- a/common/cards/card-plugins/single-use/potion-of-slowness.js
+++ b/common/cards/card-plugins/single-use/potion-of-slowness.js
@@ -12,7 +12,7 @@ class PotionOfSlownessSingleUseCard extends SingleUseCard {
 			id: 'potion_of_slowness',
 			name: 'Potion of Slowness',
 			rarity: 'common',
-			description: "Opponent's active hermit can only use their primary attack on their next turn.",
+			description: "Opponent's active Hermit can only use their primary attack on their next turn.",
 		})
 	}
 

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -54,7 +54,7 @@ export function validateDeck(deckCards: Array<string>) {
 
 	// less than one hermit
 	const hasHermit = deckCards.some((cardId) => CARDS[cardId].type === 'hermit')
-	if (!hasHermit) return 'Deck must have at least one hermit.'
+	if (!hasHermit) return 'Deck must have at least one Hermit.'
 
 	// more than max duplicates
 	const tooManyDuplicates =


### PR DESCRIPTION
This just fixes a few capitalization errors, mostly. 