### PR TITLE
added unlimitedCards option to debug-config

### DIFF
--- a/common/config/debug-config.json
+++ b/common/config/debug-config.json
@@ -7,6 +7,7 @@
 	"disableDamage": false,
 	"disableDeckOut": false,
 	"startWithAllCards": false,
+	"unlimitedCards": false,
 	"blockedActions": [],
 	"availableActions": [],
 	"showHooksState": {

--- a/server/src/routines/turn-actions/play-card.ts
+++ b/server/src/routines/turn-actions/play-card.ts
@@ -4,6 +4,7 @@ import {equalCard} from 'common/utils/cards'
 import {PlayCardActionData} from 'common/types/action-data'
 import {BasicCardPos, CardPosModel} from 'common/models/card-pos-model'
 import {ActionResult} from 'common/types/game-state'
+import {DEBUG_CONFIG} from 'common/config'
 
 function* playCardSaga(
 	game: GameModel,
@@ -107,7 +108,8 @@ function* playCardSaga(
 	}
 
 	// Remove the card from the hand
-	currentPlayer.hand = currentPlayer.hand.filter((handCard) => !equalCard(handCard, card))
+	if (!DEBUG_CONFIG.unlimitedCards)
+		currentPlayer.hand = currentPlayer.hand.filter((handCard) => !equalCard(handCard, card))
 
 	// Now it's actually been attached, remove the fake mark on the card pos
 	pos.fake = false

--- a/server/src/utils/state-gen.ts
+++ b/server/src/utils/state-gen.ts
@@ -156,10 +156,16 @@ export function getEmptyRow(): RowState {
 }
 
 export function getPlayerState(player: PlayerModel): PlayerState {
-	let pack = player.playerDeck.cards
+	const allCards = Object.values(CARDS).map(
+		(card: Card): CardT => ({
+			cardId: card.id,
+			cardInstance: card.id,
+		})
+	)
+	let pack = DEBUG_CONFIG.unlimitedCards ? allCards : player.playerDeck.cards
 
 	// shuffle cards
-	pack.sort(() => 0.5 - Math.random())
+	!DEBUG_CONFIG.unlimitedCards && pack.sort(() => 0.5 - Math.random())
 
 	// randomize instances
 	pack = pack.map((card) => {


### PR DESCRIPTION
Need to test a new card or confirm a bug? Enable `unlimitedCards` in `debug-config.json`! This option will put **every** card in your hand to be used as many time as you wish!