### PR TITLE
Add system to check if expansions have cards associated

### DIFF
--- a/client/src/app/deck/deck-edit.tsx
+++ b/client/src/app/deck/deck-edit.tsx
@@ -36,17 +36,26 @@ const DECK_ICONS = [
 	'speedrunner',
 	'terraform',
 ]
-const EXPANSION_NAMES = ['any', ...Object.keys(EXPANSIONS.expansions)]
+
+const EXPANSION_NAMES = [
+	'any',
+	...Object.keys(EXPANSIONS.expansions).filter((expansion) => {
+		return Object.values(CARDS).some((card) => card.getExpansion() === expansion)
+	}),
+]
+
 const iconDropdownOptions = DECK_ICONS.map((option) => ({
 	name: option,
 	key: option,
 	icon: `/images/types/type-${option}.png`,
 }))
+
 const rarityDropdownOptions = RANK_NAMES.map((option) => ({
 	name: option,
 	key: option,
 	icon: `/images/ranks/${option}.png`,
 }))
+
 interface ExpansionMap {
 	[key: string]: string
 }


### PR DESCRIPTION
Now, expansions will only show in the dropdown menu if they have cards associated with them. This will allow the advent of TCG stuff to be merged into main without having to remove the expansion information from expansions.json every time. We just need to disable cards.