### PR TITLE
HC-TCG Online Update v0.6.29

### DIFF
--- a/common/ailments/badomen.ts
+++ b/common/ailments/badomen.ts
@@ -33,8 +33,12 @@ class BadOmenAilment extends Ailment {
 			const targetPos = getBasicCardPos(game, ailmentInfo.targetInstance)
 			if (player.board.activeRow !== targetPos?.rowIndex) return coinFlips
 
+			// If they are not flipping on their turn, don't modify
+			const {currentPlayer} = game
+			if (currentPlayer.id !== player.id) return coinFlips
+
 			for (let i = 0; i < coinFlips.length; i++) {
-				coinFlips[i] = 'tails'
+				if (coinFlips[i]) coinFlips[i] = 'tails'
 			}
 			return coinFlips
 		})

--- a/common/ailments/sleeping.ts
+++ b/common/ailments/sleeping.ts
@@ -24,7 +24,7 @@ class SleepingAilment extends Ailment {
 		if (!card || !row?.hermitCard) return
 
 		game.state.ailments.push(ailmentInfo)
-		game.addBlockedActions('PRIMARY_ATTACK', 'SECONDARY_ATTACK', 'CHANGE_ACTIVE_HERMIT')
+		game.addBlockedActions(this.id, 'PRIMARY_ATTACK', 'SECONDARY_ATTACK', 'CHANGE_ACTIVE_HERMIT')
 		if (!ailmentInfo.duration) ailmentInfo.duration = this.duration
 
 		row.health = HERMIT_CARDS[card.cardId].health
@@ -40,7 +40,12 @@ class SleepingAilment extends Ailment {
 			}
 
 			if (player.board.activeRow === targetPos.rowIndex)
-				game.addBlockedActions('PRIMARY_ATTACK', 'SECONDARY_ATTACK', 'CHANGE_ACTIVE_HERMIT')
+				game.addBlockedActions(
+					this.id,
+					'PRIMARY_ATTACK',
+					'SECONDARY_ATTACK',
+					'CHANGE_ACTIVE_HERMIT'
+				)
 		})
 
 		player.hooks.onHermitDeath.add(ailmentInfo.ailmentInstance, (hermitPos) => {

--- a/common/ailments/slowness.ts
+++ b/common/ailments/slowness.ts
@@ -35,7 +35,8 @@ class SlownessAilment extends Ailment {
 				return
 			}
 
-			if (player.board.activeRow === targetPos.rowIndex) game.addBlockedActions('SECONDARY_ATTACK')
+			if (player.board.activeRow === targetPos.rowIndex)
+				game.addBlockedActions(this.id, 'SECONDARY_ATTACK')
 		})
 
 		player.hooks.onHermitDeath.add(ailmentInfo.ailmentInstance, (hermitPos) => {

--- a/common/cards/hermits/cubfan135-rare.ts
+++ b/common/cards/hermits/cubfan135-rare.ts
@@ -35,7 +35,7 @@ class Cubfan135RareHermitCard extends HermitCard {
 
 			// We used our secondary attack, activate power
 			// AKA remove change active hermit from blocked actions
-			game.removeBlockedActions('CHANGE_ACTIVE_HERMIT')
+			game.removeBlockedActions(null, 'CHANGE_ACTIVE_HERMIT')
 		})
 	}
 

--- a/common/cards/hermits/evilxisuma_rare.ts
+++ b/common/cards/hermits/evilxisuma_rare.ts
@@ -77,7 +77,7 @@ class EvilXisumaRareHermitCard extends HermitCard {
 
 				const actionToBlock = disable === 'primary' ? 'PRIMARY_ATTACK' : 'SECONDARY_ATTACK'
 				// This will add a blocked action for the duration of their turn
-				game.addBlockedActions(actionToBlock)
+				game.addBlockedActions(this.id, actionToBlock)
 
 				opponentPlayer.hooks.onTurnStart.remove(instance)
 				delete player.custom[disableKey]

--- a/common/cards/hermits/geminitay-rare.ts
+++ b/common/cards/hermits/geminitay-rare.ts
@@ -42,9 +42,9 @@ class GeminiTayRareHermitCard extends HermitCard {
 			}
 
 			// We are hooking into afterAttack, so we just remove the blocks on actions
-			// The beauty of this is that there is no need to replicate any of the esixting logic anymore
+			// The beauty of this is that there is no need to replicate any of the existing logic anymore
 			game.removeCompletedActions('SINGLE_USE_ATTACK', 'PLAY_SINGLE_USE_CARD')
-			game.removeBlockedActions('PLAY_SINGLE_USE_CARD')
+			game.removeBlockedActions(null, 'PLAY_SINGLE_USE_CARD')
 		})
 	}
 

--- a/common/cards/hermits/goodtimeswithscar-rare.ts
+++ b/common/cards/hermits/goodtimeswithscar-rare.ts
@@ -38,7 +38,8 @@ class GoodTimesWithScarRareHermitCard extends HermitCard {
 			player.custom[reviveNextTurn] = true
 		})
 
-		opponentPlayer.hooks.afterAttack.add(instance, () => {
+		// Add before so health can be checked reliably
+		opponentPlayer.hooks.afterAttack.addBefore(instance, () => {
 			if (player.custom[reviveNextTurn]) {
 				if (!row || row.health === null || row.health > 0) return
 

--- a/common/cards/hermits/humancleo-rare.ts
+++ b/common/cards/hermits/humancleo-rare.ts
@@ -53,7 +53,7 @@ class HumanCleoRareHermitCard extends HermitCard {
 			// Add a pick request for opponent to pick an afk hermit to attack
 			opponentPlayer.hooks.getAttackRequests.add(instance, (activeInstance, hermitAttackType) => {
 				// Only pick if there is afk to pick
-				const afk = getNonEmptyRows(opponentPlayer, false).length
+				const afk = getNonEmptyRows(opponentPlayer, true).length
 				if (afk < 1) return
 
 				game.addPickRequest({
@@ -77,7 +77,7 @@ class HumanCleoRareHermitCard extends HermitCard {
 					},
 					onTimeout() {
 						// Pick the first afk hermit to attack
-						const firstAfk = getNonEmptyRows(opponentPlayer, false)[0]
+						const firstAfk = getNonEmptyRows(opponentPlayer, true)[0]
 						if (!firstAfk) return
 
 						// Save the target index for opponent to attack

--- a/common/cards/hermits/humancleo-rare.ts
+++ b/common/cards/hermits/humancleo-rare.ts
@@ -45,7 +45,7 @@ class HumanCleoRareHermitCard extends HermitCard {
 
 			opponentPlayer.hooks.onTurnStart.add(instance, () => {
 				// The opponent needs to attack, so prevent them switching or ending turn
-				game.addBlockedActions('CHANGE_ACTIVE_HERMIT', 'END_TURN')
+				game.addBlockedActions(this.id, 'CHANGE_ACTIVE_HERMIT', 'END_TURN')
 
 				opponentPlayer.hooks.onTurnStart.remove(instance)
 			})
@@ -113,7 +113,7 @@ class HumanCleoRareHermitCard extends HermitCard {
 				}
 
 				// They attacked now, they can end turn
-				game.removeBlockedActions('END_TURN')
+				game.removeBlockedActions(this.id, 'END_TURN')
 			})
 
 			opponentPlayer.hooks.onTurnEnd.add(instance, () => {

--- a/common/cards/hermits/hypnotizd-rare.ts
+++ b/common/cards/hermits/hypnotizd-rare.ts
@@ -84,7 +84,7 @@ class HypnotizdRareHermitCard extends HermitCard {
 		player.hooks.getAttackRequests.add(instance, (activeInstance, hermitAttackType) => {
 			if (activeInstance !== instance || hermitAttackType !== 'secondary') return
 
-			const inactiveRows = getNonEmptyRows(opponentPlayer, false)
+			const inactiveRows = getNonEmptyRows(opponentPlayer, true)
 			if (inactiveRows.length === 0) return
 
 			const itemRequest: PickRequest = {

--- a/common/cards/hermits/ijevin-rare.ts
+++ b/common/cards/hermits/ijevin-rare.ts
@@ -35,7 +35,7 @@ class IJevinRareHermitCard extends HermitCard {
 			if (attack.id !== this.getInstanceKey(instance)) return
 			if (attack.type !== 'secondary' || !attack.target) return
 
-			const opponentInactiveRows = getNonEmptyRows(opponentPlayer, false)
+			const opponentInactiveRows = getNonEmptyRows(opponentPlayer, true, true)
 			if (opponentInactiveRows.length !== 0) {
 				const lastActiveRow = opponentPlayer.board.activeRow
 
@@ -61,7 +61,7 @@ class IJevinRareHermitCard extends HermitCard {
 						return 'SUCCESS'
 					},
 					onTimeout() {
-						const opponentInactiveRows = getNonEmptyRows(opponentPlayer, false)
+						const opponentInactiveRows = getNonEmptyRows(opponentPlayer, true, true)
 
 						// Choose the first afk row
 						for (const inactiveRow of opponentInactiveRows) {

--- a/common/cards/hermits/ijevin-rare.ts
+++ b/common/cards/hermits/ijevin-rare.ts
@@ -36,7 +36,7 @@ class IJevinRareHermitCard extends HermitCard {
 			if (attack.type !== 'secondary' || !attack.target) return
 
 			const opponentInactiveRows = getNonEmptyRows(opponentPlayer, false)
-			if (opponentInactiveRows.length !== 0 && attack.target.row.health) {
+			if (opponentInactiveRows.length !== 0) {
 				const lastActiveRow = opponentPlayer.board.activeRow
 
 				game.addPickRequest({

--- a/common/cards/hermits/joehills-rare.ts
+++ b/common/cards/hermits/joehills-rare.ts
@@ -49,6 +49,7 @@ class JoeHillsRareHermitCard extends HermitCard {
 			// Block all actions of opponent for one turn
 			opponentPlayer.hooks.onTurnStart.add(instance, () => {
 				game.addBlockedActions(
+					this.id,
 					'APPLY_EFFECT',
 					'REMOVE_EFFECT',
 					'SINGLE_USE_ATTACK',
@@ -68,7 +69,7 @@ class JoeHillsRareHermitCard extends HermitCard {
 			const sameActive = game.activeRow?.hermitCard?.cardInstance === player.custom[skippedKey]
 			if (player.custom[skippedKey] && sameActive) {
 				// We skipped last turn and we are still the active hermit, block secondary attacks
-				game.addBlockedActions('SECONDARY_ATTACK')
+				game.addBlockedActions(this.id, 'SECONDARY_ATTACK')
 			}
 
 			player.custom[skippedKey] = null

--- a/common/cards/hermits/keralis-rare.ts
+++ b/common/cards/hermits/keralis-rare.ts
@@ -42,10 +42,10 @@ class KeralisRareHermitCard extends HermitCard {
 			if (hermitAttackType !== 'secondary') return
 
 			// Make sure there is something to select
-			const playerHasAfk = getNonEmptyRows(player, false).some(
+			const playerHasAfk = getNonEmptyRows(player, true).some(
 				(rowPos) => HERMIT_CARDS[rowPos.row.hermitCard.cardId] !== undefined
 			)
-			const opponentHasAfk = getNonEmptyRows(opponentPlayer, false).some(
+			const opponentHasAfk = getNonEmptyRows(opponentPlayer, true).some(
 				(rowPos) => HERMIT_CARDS[rowPos.row.hermitCard.cardId] !== undefined
 			)
 			if (!playerHasAfk && !opponentHasAfk) return

--- a/common/cards/hermits/rendog-rare.ts
+++ b/common/cards/hermits/rendog-rare.ts
@@ -4,7 +4,6 @@ import {GameModel} from '../../models/game-model'
 import {CardPosModel, getBasicCardPos} from '../../models/card-pos-model'
 import {HermitAttackType} from '../../types/attack'
 import {CardT} from '../../types/game-state'
-import {getNonEmptyRows} from '../../utils/board'
 
 class RendogRareHermitCard extends HermitCard {
 	constructor() {

--- a/common/cards/hermits/tangotek-rare.ts
+++ b/common/cards/hermits/tangotek-rare.ts
@@ -40,14 +40,14 @@ class TangoTekRareHermitCard extends HermitCard {
 			)
 				return
 
-			const opponentInactiveRows = getNonEmptyRows(opponentPlayer, false)
-			const playerInactiveRows = getNonEmptyRows(player, false)
+			const opponentInactiveRows = getNonEmptyRows(opponentPlayer, true, true)
+			const playerInactiveRows = getNonEmptyRows(player, true, true)
 
 			// Curse of Binding
 			const canChange = isActionAvailable(game, 'CHANGE_ACTIVE_HERMIT')
 
 			// If opponent has hermit they can switch to, add a pick request for them to switch
-			if (opponentInactiveRows.length !== 0) {
+			if (opponentInactiveRows.length > 0) {
 				// Add a new pick request to the opponent player
 				game.addPickRequest({
 					playerId: opponentPlayer.id,
@@ -66,7 +66,7 @@ class TangoTekRareHermitCard extends HermitCard {
 						return 'SUCCESS'
 					},
 					onTimeout() {
-						const opponentInactiveRows = getNonEmptyRows(opponentPlayer, false)
+						const opponentInactiveRows = getNonEmptyRows(opponentPlayer, true, true)
 
 						// Choose the first afk row
 						for (const inactiveRow of opponentInactiveRows) {
@@ -105,7 +105,7 @@ class TangoTekRareHermitCard extends HermitCard {
 						return 'SUCCESS'
 					},
 					onTimeout() {
-						const inactiveRows = getNonEmptyRows(player, false)
+						const inactiveRows = getNonEmptyRows(player, true, true)
 
 						// Choose the first afk row
 						for (const inactiveRow of inactiveRows) {

--- a/common/cards/hermits/tangotek-rare.ts
+++ b/common/cards/hermits/tangotek-rare.ts
@@ -1,7 +1,6 @@
 import {CardPosModel} from '../../models/card-pos-model'
 import {GameModel} from '../../models/game-model'
 import {getNonEmptyRows} from '../../utils/board'
-import {isActionAvailable} from '../../utils/game'
 import HermitCard from '../base/hermit-card'
 
 class TangoTekRareHermitCard extends HermitCard {
@@ -44,7 +43,7 @@ class TangoTekRareHermitCard extends HermitCard {
 			const playerInactiveRows = getNonEmptyRows(player, true, true)
 
 			// Curse of Binding
-			const canChange = isActionAvailable(game, 'CHANGE_ACTIVE_HERMIT')
+			const canChange = game.isActionBlocked('CHANGE_ACTIVE_HERMIT', [null])
 
 			// If opponent has hermit they can switch to, add a pick request for them to switch
 			if (opponentInactiveRows.length > 0) {

--- a/common/cards/hermits/zombiecleo-rare.ts
+++ b/common/cards/hermits/zombiecleo-rare.ts
@@ -133,6 +133,7 @@ class ZombieCleoRareHermitCard extends HermitCard {
 			})
 		})
 
+		// @TODO requires getActions to be able to remove
 		player.hooks.blockedActions.add(instance, (blockedActions) => {
 			const afkHermits = getNonEmptyRows(player, true).length
 			if (

--- a/common/cards/hermits/zombiecleo-rare.ts
+++ b/common/cards/hermits/zombiecleo-rare.ts
@@ -72,7 +72,7 @@ class ZombieCleoRareHermitCard extends HermitCard {
 			if (hermitAttackType !== 'secondary') return
 
 			// Make sure we have an afk hermit to pick
-			const afk = getNonEmptyRows(player, false)
+			const afk = getNonEmptyRows(player, true)
 			if (afk.length === 0) return
 
 			game.addPickRequest({
@@ -134,7 +134,7 @@ class ZombieCleoRareHermitCard extends HermitCard {
 		})
 
 		player.hooks.blockedActions.add(instance, (blockedActions) => {
-			const afkHermits = getNonEmptyRows(player, false).length
+			const afkHermits = getNonEmptyRows(player, true).length
 			if (
 				player.board.activeRow === pos.rowIndex &&
 				afkHermits <= 0 &&

--- a/common/cards/single-use/bow.ts
+++ b/common/cards/single-use/bow.ts
@@ -22,7 +22,7 @@ class BowSingleUseCard extends SingleUseCard {
 		const {opponentPlayer} = pos
 
 		// Check if there is an AFK Hermit
-		const inactiveRows = getNonEmptyRows(opponentPlayer, false)
+		const inactiveRows = getNonEmptyRows(opponentPlayer, true)
 		if (inactiveRows.length === 0) return 'NO'
 
 		return 'YES'

--- a/common/cards/single-use/chorus-fruit.ts
+++ b/common/cards/single-use/chorus-fruit.ts
@@ -19,7 +19,7 @@ class ChorusFruitSingleUseCard extends SingleUseCard {
 
 		player.hooks.afterAttack.add(instance, (attack) => {
 			// Remove change active hermit from the blocked actions so it can be done once more
-			game.removeBlockedActions('CHANGE_ACTIVE_HERMIT')
+			game.removeBlockedActions(null, 'CHANGE_ACTIVE_HERMIT')
 
 			// Apply the card
 			applySingleUse(game)

--- a/common/cards/single-use/clock.ts
+++ b/common/cards/single-use/clock.ts
@@ -25,6 +25,7 @@ class ClockSingleUseCard extends SingleUseCard {
 		player.hooks.onApply.add(instance, () => {
 			opponentPlayer.hooks.onTurnStart.add(instance, () => {
 				game.addBlockedActions(
+					this.id,
 					'APPLY_EFFECT',
 					'REMOVE_EFFECT',
 					'SINGLE_USE_ATTACK',

--- a/common/cards/single-use/curse-of-binding.ts
+++ b/common/cards/single-use/curse-of-binding.ts
@@ -21,23 +21,10 @@ class CurseOfBindingSingleUseCard extends SingleUseCard {
 		const {opponentPlayer, player} = pos
 
 		player.hooks.onApply.add(instance, () => {
-			opponentPlayer.hooks.blockedActions.add(instance, (blockedActions) => {
-				if (blockedActions.includes('CHANGE_ACTIVE_HERMIT')) {
-					return blockedActions
-				}
+			opponentPlayer.hooks.onTurnStart.add(instance, () => {
+				game.addBlockedActions(this.id, 'CHANGE_ACTIVE_HERMIT')
 
-				// Make sure the other player has an active row
-				if (opponentPlayer.board.activeRow !== null) {
-					blockedActions.push('CHANGE_ACTIVE_HERMIT')
-				}
-
-				return blockedActions
-			})
-
-			opponentPlayer.hooks.onTurnEnd.add(instance, () => {
-				// Remove effects of card and clean up
-				opponentPlayer.hooks.blockedActions.remove(instance)
-				opponentPlayer.hooks.onTurnEnd.remove(instance)
+				opponentPlayer.hooks.onTurnStart.remove(instance)
 			})
 		})
 	}

--- a/common/cards/single-use/egg.ts
+++ b/common/cards/single-use/egg.ts
@@ -23,7 +23,7 @@ class EggSingleUseCard extends SingleUseCard {
 
 		const {opponentPlayer} = pos
 
-		const inactiveHermits = getNonEmptyRows(opponentPlayer, false)
+		const inactiveHermits = getNonEmptyRows(opponentPlayer, true)
 		if (inactiveHermits.length === 0) return 'NO'
 
 		return 'YES'

--- a/common/cards/single-use/golden-apple.ts
+++ b/common/cards/single-use/golden-apple.ts
@@ -26,7 +26,7 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 		if (!isActive(player)) return 'NO'
 
 		// Can't attach it there are not any inactive hermits
-		const playerHasAfk = getNonEmptyRows(player, false).some(
+		const playerHasAfk = getNonEmptyRows(player, true).some(
 			(rowPos) => HERMIT_CARDS[rowPos.row.hermitCard.cardId] !== undefined
 		)
 		if (!playerHasAfk) return 'NO'

--- a/common/cards/single-use/knockback.ts
+++ b/common/cards/single-use/knockback.ts
@@ -22,7 +22,7 @@ class KnockbackSingleUseCard extends SingleUseCard {
 		const {opponentPlayer} = pos
 
 		// Check if there is an AFK Hermit
-		const inactiveRows = getNonEmptyRows(opponentPlayer, false)
+		const inactiveRows = getNonEmptyRows(opponentPlayer, true)
 		if (inactiveRows.length === 0) return 'NO'
 
 		return 'YES'
@@ -66,7 +66,7 @@ class KnockbackSingleUseCard extends SingleUseCard {
 						return 'SUCCESS'
 					},
 					onTimeout() {
-						const opponentInactiveRows = getNonEmptyRows(opponentPlayer, false)
+						const opponentInactiveRows = getNonEmptyRows(opponentPlayer, true)
 
 						// Choose the first afk row
 						for (const inactiveRow of opponentInactiveRows) {

--- a/common/cards/single-use/lead.ts
+++ b/common/cards/single-use/lead.ts
@@ -32,7 +32,7 @@ class LeadSingleUseCard extends SingleUseCard {
 
 		const activeRow = getActiveRow(opponentPlayer)
 		if (!activeRow || !rowHasItem(activeRow)) return 'NO'
-		const rowsWithEmptySlots = getRowsWithEmptyItemsSlots(opponentPlayer, false)
+		const rowsWithEmptySlots = getRowsWithEmptyItemsSlots(opponentPlayer, true)
 		if (rowsWithEmptySlots.length === 0) return 'NO'
 
 		// check if the card can be attached to any of the inactive hermits

--- a/common/cards/single-use/mending.ts
+++ b/common/cards/single-use/mending.ts
@@ -28,7 +28,7 @@ class MendingSingleUseCard extends singleUseCard {
 		if (!effectCard || !isRemovable(effectCard)) return 'NO'
 
 		// check if there is an empty slot available to move the effect card to
-		const inactiveHermits = getNonEmptyRows(player, false)
+		const inactiveHermits = getNonEmptyRows(player, true)
 		for (const hermit of inactiveHermits) {
 			if (!hermit) continue
 			const effect = hermit.row.effectCard

--- a/common/cards/single-use/target-block.ts
+++ b/common/cards/single-use/target-block.ts
@@ -22,7 +22,7 @@ class TargetBlockSingleUseCard extends SingleUseCard {
 		const {opponentPlayer} = pos
 
 		// Inactive Hermits
-		if (getNonEmptyRows(opponentPlayer, false).length === 0) return 'NO'
+		if (getNonEmptyRows(opponentPlayer, true).length === 0) return 'NO'
 
 		return 'YES'
 	}

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -111,21 +111,65 @@ export class GameModel {
 	}
 
 	/** Set actions as blocked so they cannot be done this turn */
-	public addBlockedActions(...actions: TurnActions) {
+	public addBlockedActions(sourceId: string | null, ...actions: TurnActions) {
+		const key = sourceId || ''
+		const turnState = this.state.turn
+		if (!turnState.blockedActions[key]) {
+			turnState.blockedActions[key] = []
+		}
+
 		for (let i = 0; i < actions.length; i++) {
 			const action = actions[i]
-			if (!this.state.turn.blockedActions.includes(action)) {
-				this.state.turn.blockedActions.push(action)
+			if (!turnState.blockedActions[key].includes(action)) {
+				turnState.blockedActions[key].push(action)
 			}
 		}
 	}
 	/** Remove action from the completed list so they can be done again this turn */
-	public removeBlockedActions(...actions: TurnActions) {
+	public removeBlockedActions(sourceId: string | null, ...actions: TurnActions) {
+		const key = sourceId || ''
+		const turnState = this.state.turn
+		if (!turnState.blockedActions[key]) return
+
 		for (let i = 0; i < actions.length; i++) {
-			this.state.turn.blockedActions = this.state.turn.blockedActions.filter(
+			turnState.blockedActions[key] = turnState.blockedActions[key].filter(
 				(action) => !actions.includes(action)
 			)
 		}
+
+		if (turnState.blockedActions[key].length <= 0) {
+			delete turnState.blockedActions[key]
+		}
+	}
+
+	public isActionBlocked(action: TurnAction, excludeIds?: Array<string | null>) {
+		const turnState = this.state.turn
+		const allBlockedActions: TurnActions = []
+		Object.keys(turnState.blockedActions).forEach((sourceId) => {
+			if (excludeIds?.includes(sourceId)) return
+
+			const actions = turnState.blockedActions[sourceId]
+			allBlockedActions.push(...actions)
+		})
+		return allBlockedActions.includes(action)
+	}
+
+	/** Get all actions blocked with the source id. */
+	public getBlockedActions(sourceId: string | null) {
+		const key = sourceId || ''
+		const turnState = this.state.turn
+		const blockedActions = turnState.blockedActions[key]
+		if (!blockedActions) return []
+
+		return blockedActions
+	}
+	public getAllBlockedActions() {
+		const turnState = this.state.turn
+		const allBlockedActions: TurnActions = []
+		Object.values(turnState.blockedActions).forEach((actions) => {
+			allBlockedActions.push(...actions)
+		})
+		return allBlockedActions
 	}
 
 	public setLastActionResult(action: TurnAction, result: ActionResult) {

--- a/common/types/game-state.ts
+++ b/common/types/game-state.ts
@@ -172,7 +172,8 @@ export type TurnState = {
 	availableActions: TurnActions
 	opponentAvailableActions: TurnActions
 	completedActions: TurnActions
-	blockedActions: TurnActions
+	/** Map of source id of the block, to the actual blocked action */
+	blockedActions: Record<string, TurnActions>
 
 	currentAttack: HermitAttackType | null
 }

--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -176,6 +176,7 @@ export function executeAttacks(
 		// STEP 5 - All attacks have been completed, mark actions appropriately
 		game.addCompletedActions('SINGLE_USE_ATTACK', 'PRIMARY_ATTACK', 'SECONDARY_ATTACK')
 		game.addBlockedActions(
+			null,
 			'PLAY_HERMIT_CARD',
 			'PLAY_ITEM_CARD',
 			'PLAY_EFFECT_CARD',

--- a/common/utils/board.ts
+++ b/common/utils/board.ts
@@ -57,15 +57,19 @@ export function isRowEmpty(row: RowStateWithHermit): boolean {
 	return row.itemCards.filter((card) => !!card).length === 0
 }
 
+// @NOTE - ignoreNegativeHealth should be true when being used in afterAttack,
+// as health may be below 0 but hermits will not have been removed from the board yet
 export function getNonEmptyRows(
 	playerState: PlayerState,
-	includeActive: boolean = true
+	ignoreActive: boolean = false,
+	ignoreNegativeHealth: boolean = false
 ): Array<RowPos> {
 	const rows: Array<RowPos> = []
 	const activeRowIndex = playerState.board.activeRow
 	for (let i = 0; i < playerState.board.rows.length; i++) {
 		const row = playerState.board.rows[i]
-		if (i === activeRowIndex && !includeActive) continue
+		if (i === activeRowIndex && ignoreActive) continue
+		if ((!row.health || row.health < 0) && ignoreNegativeHealth) continue
 		if (row.hermitCard) rows.push({player: playerState, rowIndex: i, row})
 	}
 	return rows
@@ -73,14 +77,14 @@ export function getNonEmptyRows(
 
 export function getRowsWithEmptyItemsSlots(
 	playerState: PlayerState,
-	includeActive: boolean = true
+	ignoreActive: boolean = false
 ): RowStateWithHermit[] {
 	const result: Array<RowStateWithHermit> = []
 	const activeRow = playerState.board.activeRow
 	const rows = playerState.board.rows
 	for (let i = 0; i < rows.length; i++) {
 		const row = rows[i]
-		if (i === activeRow && !includeActive) continue
+		if (i === activeRow && ignoreActive) continue
 		if (row.hermitCard && !isRowFull(row)) result.push(row)
 	}
 	return result

--- a/common/utils/game.ts
+++ b/common/utils/game.ts
@@ -4,7 +4,3 @@ import {TurnAction, PlayerState} from '../types/game-state'
 export function isActive(playerState: PlayerState): boolean {
 	return playerState.board.activeRow !== null
 }
-
-export function isActionAvailable(game: GameModel, action: TurnAction) {
-	return game.state.turn.availableActions.includes(action)
-}

--- a/common/utils/state-gen.ts
+++ b/common/utils/state-gen.ts
@@ -13,7 +13,7 @@ export function getGameState(game: GameModel): GameState {
 			availableActions: [],
 			opponentAvailableActions: [],
 			completedActions: [],
-			blockedActions: [],
+			blockedActions: {},
 			currentAttack: null,
 		},
 		order: playerIds,

--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -160,10 +160,9 @@ function getAvailableActions(game: GameModel, availableEnergy: Array<EnergyT>): 
 
 	// Filter out actions that have already been completed - once an action is completed it cannot be used again for the turn
 	// Also filter out blocked actions
+	const blockedActions = game.getAllBlockedActions()
 	let filteredActions = actions.filter((action) => {
-		return (
-			!turnState.completedActions.includes(action) && !turnState.blockedActions.includes(action)
-		)
+		return !turnState.completedActions.includes(action) && !blockedActions.includes(action)
 	})
 
 	// Force add change active hermit if the active row is null
@@ -172,16 +171,6 @@ function getAvailableActions(game: GameModel, availableEnergy: Array<EnergyT>): 
 	}
 
 	return filteredActions
-}
-
-function getBlockedActions(game: GameModel): TurnActions {
-	const {currentPlayer} = game
-
-	const actions: TurnActions = []
-
-	const {activeRow, rows} = currentPlayer.board
-
-	return actions
 }
 
 function playerAction(actionType: string, playerId: string) {
@@ -353,7 +342,7 @@ function* turnActionsSaga(game: GameModel) {
 
 			// Available actions code
 			const availableEnergy = getAvailableEnergy(game)
-			let blockedActions = getBlockedActions(game)
+			let blockedActions: Array<TurnAction> = []
 			let availableActions = getAvailableActions(game, availableEnergy)
 
 			// Get blocked actions from hooks
@@ -394,8 +383,6 @@ function* turnActionsSaga(game: GameModel) {
 			) {
 				break
 			}
-
-			game.state.turn.availableActions = availableActions
 
 			// End of available actions code
 
@@ -509,7 +496,7 @@ function* turnSaga(game: GameModel) {
 	game.state.turn.availableActions = []
 	game.state.turn.currentPlayerId = currentPlayerId
 	game.state.turn.completedActions = []
-	game.state.turn.blockedActions = []
+	game.state.turn.blockedActions = {}
 	game.state.turn.currentAttack = null
 
 	game.state.timer.turnStartTime = Date.now()

--- a/server/src/routines/turn-actions/change-active-hermit.ts
+++ b/server/src/routines/turn-actions/change-active-hermit.ts
@@ -36,6 +36,7 @@ function* changeActiveHermit(
 
 		// Attack phase complete, mark most actions as blocked now
 		game.addBlockedActions(
+			null,
 			'SINGLE_USE_ATTACK',
 			'PRIMARY_ATTACK',
 			'SECONDARY_ATTACK',


### PR DESCRIPTION
HC-TCG Online Update v0.6.29 Changelog: 
- Fixed totem preventing ijevin from causing a hermit switch
- Fixed jevin and tango still calling for a hermit switch when the afk hermit was knocked out by an afk snipe
- Fixed bad omen affecting the second flip of zedaph
- Fixed ren not copying tango properly
- Changed the splash text to "Advent of TCG"