### PR TITLE
A few bug fixes for christmas cards

### DIFF
--- a/common/ailments/museum-collection.ts
+++ b/common/ailments/museum-collection.ts
@@ -49,7 +49,14 @@ class MuseumCollectionAilment extends Ailment {
 				attack.type !== 'secondary'
 			)
 				return
-			if (!ailmentInfo.duration) return
+			if (ailmentInfo.duration === undefined) return
+
+			player.hooks.onApply.remove(ailmentInfo.ailmentInstance)
+			player.hooks.onApply.add(ailmentInfo.ailmentInstance, () => {
+				if (ailmentInfo.duration === undefined) return
+				ailmentInfo.duration++
+				attack.addDamage(this.id, 20)
+			})
 
 			attack.addDamage(this.id, 20 * ailmentInfo.duration)
 		})

--- a/common/cards/advent-of-tcg/effects/trapdoor.ts
+++ b/common/cards/advent-of-tcg/effects/trapdoor.ts
@@ -60,9 +60,10 @@ class TrapdoorEffectCard extends EffectCard {
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {
-		const {opponentPlayer} = pos
+		const {player} = pos
 
-		opponentPlayer.hooks.onAttack.remove(instance)
+		player.hooks.onDefence.remove(instance)
+		player.hooks.afterDefence.remove(instance)
 	}
 
 	public override getExpansion(): string {

--- a/common/cards/advent-of-tcg/hermits/ldshadowlady-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/ldshadowlady-rare.ts
@@ -1,7 +1,6 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {getActiveRow, getNonEmptyRows} from '../../../utils/board'
-import {swapRows} from '../../../utils/movement'
 import HermitCard from '../../base/hermit-card'
 
 class LDShadowLadyRareHermitCard extends HermitCard {
@@ -62,8 +61,7 @@ class LDShadowLadyRareHermitCard extends HermitCard {
 					if (pickResult.rowIndex === opponentPlayer.board.activeRow) return 'FAILURE_WRONG_PICK'
 					if (opponentPlayer.board.activeRow === null) return 'FAILURE_INVALID_DATA'
 
-					swapRows(opponentPlayer, opponentPlayer.board.activeRow, pickResult.rowIndex)
-					game.changeActiveRow(opponentPlayer, pickResult.rowIndex)
+					game.swapRows(opponentPlayer, opponentPlayer.board.activeRow, pickResult.rowIndex)
 
 					return 'SUCCESS'
 				},
@@ -77,8 +75,7 @@ class LDShadowLadyRareHermitCard extends HermitCard {
 
 					const pickedRowIndex = emptyRows[Math.floor(Math.random() * emptyRows.length)]
 
-					swapRows(opponentPlayer, opponentPlayer.board.activeRow, pickedRowIndex)
-					game.changeActiveRow(opponentPlayer, pickedRowIndex)
+					game.swapRows(opponentPlayer, opponentPlayer.board.activeRow, pickedRowIndex)
 				},
 			})
 		})

--- a/common/cards/advent-of-tcg/hermits/smallishbeans-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/smallishbeans-rare.ts
@@ -1,5 +1,6 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
+import {getActiveRowPos} from '../../../utils/board'
 import HermitCard from '../../base/hermit-card'
 
 class SmallishbeansRareHermitCard extends HermitCard {
@@ -33,11 +34,12 @@ class SmallishbeansRareHermitCard extends HermitCard {
 			const attackId = this.getInstanceKey(instance)
 			if (attack.id !== attackId || attack.type !== 'secondary') return
 
-			if (!row) return
+			const activeRow = getActiveRowPos(player)
+			if (!activeRow) return
 
 			let partialSum = 0
 
-			row.itemCards.forEach((item) => {
+			activeRow.row.itemCards.forEach((item) => {
 				if (!item) return
 				if (item.cardId.includes('rare')) partialSum += 1
 				partialSum += 1

--- a/common/cards/advent-of-tcg/single-use/glowstone.ts
+++ b/common/cards/advent-of-tcg/single-use/glowstone.ts
@@ -40,7 +40,8 @@ class GlowstoneSingleUseCard extends SingleUseCard {
 				},
 				onResult(modalResult) {
 					if (!modalResult) return 'FAILURE_INVALID_DATA'
-					if (!modalResult.cards) return 'SUCCESS'
+					if (!modalResult.cards) return 'FAILURE_INVALID_DATA'
+					if (modalResult.cards.length !== 1) return 'FAILURE_INVALID_DATA'
 
 					const cards: Array<CardT> = modalResult.cards
 					const bottomCards: Array<CardT> = opponentPlayer.pile.slice(0, 3).filter((c) => {

--- a/common/cards/advent-of-tcg/single-use/lantern.ts
+++ b/common/cards/advent-of-tcg/single-use/lantern.ts
@@ -50,7 +50,7 @@ class LanternSingleUseCard extends SingleUseCard {
 				},
 				onResult(modalResult) {
 					if (!modalResult) return 'FAILURE_INVALID_DATA'
-					if (!modalResult.cards) return 'SUCCESS'
+					if (!modalResult.cards) return 'FAILURE_INVALID_DATA'
 					if (modalResult.cards.length !== 2) return 'FAILURE_INVALID_DATA'
 
 					const cards: Array<CardT> = modalResult.cards

--- a/common/cards/alter-egos/single-use/ender-pearl.ts
+++ b/common/cards/alter-egos/single-use/ender-pearl.ts
@@ -1,7 +1,6 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {applySingleUse, getActiveRow, getActiveRowPos} from '../../../utils/board'
-import {swapRows} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
 
 class EnderPearlSingleUseCard extends SingleUseCard {
@@ -52,8 +51,7 @@ class EnderPearlSingleUseCard extends SingleUseCard {
 				if (player.board.activeRow === null) return 'FAILURE_INVALID_DATA'
 				const activeRow = getActiveRowPos(player)
 				if (activeRow?.row.health) activeRow.row.health -= 10
-				swapRows(player, player.board.activeRow, rowIndex)
-				game.changeActiveRow(player, rowIndex)
+				game.swapRows(player, player.board.activeRow, rowIndex)
 
 				return 'SUCCESS'
 			},

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -1,5 +1,5 @@
 import {GameModel} from '../models/game-model'
-import {CardT, PlayerState} from '../types/game-state'
+import {CardT, GameState, PlayerState} from '../types/game-state'
 import {CARDS} from '../cards'
 import {CardPosModel, getCardPos} from '../models/card-pos-model'
 import {equalCard} from './cards'
@@ -240,24 +240,4 @@ export function swapSlots(
 			cardPos.player.hooks.onAttach.call(card.cardInstance)
 		}
 	}
-}
-
-/**Swaps the positions of two rows on the board. */
-export function swapRows(player: PlayerState, oldRow: number, newRow: number) {
-	const oldRowState = player.board.rows[oldRow]
-
-	const oldSlotPos: SlotPos = {
-		rowIndex: oldRow,
-		row: oldRowState,
-		slot: {
-			index: 0,
-			type: 'hermit',
-		},
-	}
-
-	const results = player.hooks.onSlotChange.call(oldSlotPos)
-	if (results.includes(false)) return
-
-	player.board.rows[oldRow] = player.board.rows[newRow]
-	player.board.rows[newRow] = oldRowState
 }


### PR DESCRIPTION
Joel: Small change, but this allows joel to work properly with cleo without having to change how her cards works. otherwise, works the same.
Biffa: The onApply hook is replaced with one that directly adds damage to the Hermit's secondary attack for all attacks that are added after the hooks for the secondary are added. Now effects that apply themselves after their attack hook still work
Lizzie/swapRows function: Switched to a helper function on game to be more similar to changeActiveRow. In addition, it now automatically changes the active row (if possible) within the function to prevent mistakes. If the active row cannot change, the rows are not swapped as well to prevent the wrong row from being active.
Fix trapdoor hooks
Slightly modified lantern/glowstone to show again when they're closed with the wrong number of cards selected