### PR TITLE
Grianch fix

### DIFF
--- a/common/cards/advent-of-tcg/hermits/grianch-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/grianch-rare.ts
@@ -57,6 +57,9 @@ class GrianchRareHermitCard extends HermitCard {
 		player.hooks.afterAttack.add(instance, (attack) => {
 			if (attack.id !== instanceKey || attack.type !== 'primary') return
 
+			const nonEmptyRows = getNonEmptyRows(player, true, true)
+			if (nonEmptyRows.length === 0) return
+
 			game.addPickRequest({
 				playerId: player.id,
 				id: this.id,


### PR DESCRIPTION
make grianch check for AFK on his primary ability, it was possible to use without any AFK hermits so you'd have to wait for timeout