### PR TITLE
Fixes coin flip edge cases

### DIFF
--- a/common/cards/advent-of-tcg/effects/brewing-stand.ts
+++ b/common/cards/advent-of-tcg/effects/brewing-stand.ts
@@ -26,7 +26,7 @@ class BrewingStandEffectCard extends EffectCard {
 
 			if (pos.rowIndex !== player.board.activeRow) return
 
-			const flip = flipCoin(player, this.id)[0]
+			const flip = flipCoin(player, {cardId: this.id, cardInstance: instance})[0]
 			if (flip !== 'heads') return
 
 			game.addPickRequest({

--- a/common/cards/advent-of-tcg/hermits/grianch-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/grianch-rare.ts
@@ -35,9 +35,9 @@ class GrianchRareHermitCard extends HermitCard {
 		const instanceKey = this.getInstanceKey(instance)
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== instanceKey || attack.type !== 'secondary') return
+			if (attack.id !== instanceKey || attack.type !== 'secondary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 
 			if (coinFlip[0] === 'tails') {
 				opponentPlayer.hooks.afterAttack.add(instance, (attack) => {

--- a/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
@@ -33,9 +33,14 @@ class MonkeyfarmRareHermitCard extends HermitCard {
 		const {player, opponentPlayer} = pos
 
 		player.hooks.afterAttack.add(instance, (attack) => {
-			if (attack.id !== this.getInstanceKey(instance) || attack.type !== 'secondary') return
+			if (
+				attack.id !== this.getInstanceKey(instance) ||
+				attack.type !== 'secondary' ||
+				!attack.attacker
+			)
+				return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 			if (coinFlip[0] !== 'heads') return
 
 			const emptyRows = getNonEmptyRows(opponentPlayer, true, true)

--- a/common/cards/advent-of-tcg/hermits/pharaoh-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/pharaoh-rare.ts
@@ -1,7 +1,7 @@
 import {CARDS, HERMIT_CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {getNonEmptyRows} from '../../../utils/board'
+import {getActiveRow, getNonEmptyRows} from '../../../utils/board'
 import {flipCoin} from '../../../utils/coinFlips'
 import HermitCard from '../../base/hermit-card'
 
@@ -53,7 +53,10 @@ class PharaohRareHermitCard extends HermitCard {
 				return
 			}
 
-			const coinFlip = flipCoin(player, this.id)
+			const attacker = getActiveRow(player)?.hermitCard
+			if (!attacker) return
+
+			const coinFlip = flipCoin(player, attacker)
 
 			if (coinFlip[0] === 'tails') return
 

--- a/common/cards/alter-egos/hermits/evilxisuma_rare.ts
+++ b/common/cards/alter-egos/hermits/evilxisuma_rare.ts
@@ -36,7 +36,7 @@ class EvilXisumaRareHermitCard extends HermitCard {
 
 		player.hooks.afterAttack.add(instance, (attack) => {
 			if (attack.id !== this.getInstanceKey(instance)) return
-			if (attack.type !== 'secondary') return
+			if (attack.type !== 'secondary' || !attack.attacker) return
 
 			const opponentActiveRow = getActiveRowPos(opponentPlayer)
 			if (!opponentActiveRow) return
@@ -44,7 +44,7 @@ class EvilXisumaRareHermitCard extends HermitCard {
 
 			if (!HERMIT_CARDS[opponentActiveRow.row.hermitCard.cardId]) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 
 			if (coinFlip[0] !== 'heads') return
 

--- a/common/cards/alter-egos/hermits/goatfather-rare.ts
+++ b/common/cards/alter-egos/hermits/goatfather-rare.ts
@@ -40,15 +40,15 @@ class GoatfatherRareHermitCard extends HermitCard {
 
 		const {player, opponentPlayer, row, rowIndex} = pos
 
-		if (attacks[0].type !== 'secondary') return attacks
+		if (attacks[0].type !== 'secondary' || !row?.hermitCard) return attacks
 
-		const coinFlip = flipCoin(player, this.id)
+		const coinFlip = flipCoin(player, row.hermitCard)
 
 		if (coinFlip[0] === 'tails') return attacks
 
 		const activeRow = opponentPlayer.board.activeRow
 		const rows = opponentPlayer.board.rows
-		if (activeRow === null || rowIndex === null || !row || !row.hermitCard) return attacks
+		if (activeRow === null || rowIndex === null) return attacks
 		for (let i = activeRow; i < rows.length; i++) {
 			const targetRow = rows[i]
 			if (!targetRow.hermitCard) continue

--- a/common/cards/alter-egos/hermits/helsknight-rare.ts
+++ b/common/cards/alter-egos/hermits/helsknight-rare.ts
@@ -33,11 +33,17 @@ class HelsknightRareHermitCard extends HermitCard {
 		const {player, opponentPlayer} = pos
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== this.getInstanceKey(instance) || attack.type !== 'secondary') return
+			if (
+				attack.id !== this.getInstanceKey(instance) ||
+				attack.type !== 'secondary' ||
+				!attack.attacker
+			)
+				return
 
+			const attacker = attack.attacker.row.hermitCard
 			opponentPlayer.hooks.onApply.add(instance, () => {
 				if (!opponentPlayer.board.singleUseCard) return
-				const coinFlip = flipCoin(player, this.id, 1, opponentPlayer)
+				const coinFlip = flipCoin(player, attacker, 1, opponentPlayer)
 
 				if (coinFlip[0] == 'heads') {
 					moveCardToHand(game, opponentPlayer.board.singleUseCard, true)

--- a/common/cards/alter-egos/hermits/humancleo-rare.ts
+++ b/common/cards/alter-egos/hermits/humancleo-rare.ts
@@ -37,9 +37,9 @@ class HumanCleoRareHermitCard extends HermitCard {
 		const opponentTargetKey = this.getInstanceKey(instance, 'opponentTarget')
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== instanceKey || attack.type !== 'secondary') return
+			if (attack.id !== instanceKey || attack.type !== 'secondary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id, 2)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard, 2)
 
 			const headsAmount = coinFlip.filter((flip) => flip === 'heads').length
 			if (headsAmount < 2) return

--- a/common/cards/alter-egos/hermits/jingler-rare.ts
+++ b/common/cards/alter-egos/hermits/jingler-rare.ts
@@ -34,8 +34,8 @@ class JinglerRareHermitCard extends HermitCard {
 
 		player.hooks.afterAttack.add(instance, (attack) => {
 			if (attack.id !== this.getInstanceKey(instance)) return
-			if (attack.type !== 'secondary' || !attack.target) return
-			const coinFlip = flipCoin(player, this.id)
+			if (attack.type !== 'secondary' || !attack.target || !attack.attacker) return
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 			if (coinFlip[0] === 'tails') return
 
 			// Add a new pick request for the opponent player

--- a/common/cards/alter-egos/hermits/llamadad-rare.ts
+++ b/common/cards/alter-egos/hermits/llamadad-rare.ts
@@ -31,9 +31,14 @@ class LlamadadRareHermitCard extends HermitCard {
 		const {player} = pos
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== this.getInstanceKey(instance) || attack.type !== 'secondary') return
+			if (
+				attack.id !== this.getInstanceKey(instance) ||
+				attack.type !== 'secondary' ||
+				!attack.attacker
+			)
+				return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 			if (coinFlip[0] === 'heads') {
 				attack.addDamage(this.id, 40)
 			}

--- a/common/cards/alter-egos/single-use/egg.ts
+++ b/common/cards/alter-egos/single-use/egg.ts
@@ -74,7 +74,7 @@ class EggSingleUseCard extends SingleUseCard {
 				[`${CARDS[targetRow.hermitCard.cardId].name} `, 'opponent'],
 			])
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, {cardId: this.id, cardInstance: instance})
 			if (coinFlip[0] === 'heads') {
 				const eggAttack = new AttackModel({
 					id: this.getInstanceKey(instance),

--- a/common/cards/alter-egos/single-use/trident.ts
+++ b/common/cards/alter-egos/single-use/trident.ts
@@ -42,7 +42,10 @@ class TridentSingleUseCard extends SingleUseCard {
 			const attackId = this.getInstanceKey(instance)
 			if (attack.id !== attackId) return
 
-			player.custom[this.getInstanceKey(instance)] = flipCoin(player, this.id)[0]
+			player.custom[this.getInstanceKey(instance)] = flipCoin(player, {
+				cardId: this.id,
+				cardInstance: instance,
+			})[0]
 
 			const opponentActiveHermitId = getActiveRowPos(opponentPlayer)?.row.hermitCard.cardId
 			applySingleUse(game, [

--- a/common/cards/default/hermits/docm77-rare.ts
+++ b/common/cards/default/hermits/docm77-rare.ts
@@ -33,9 +33,9 @@ class Docm77RareHermitCard extends HermitCard {
 
 		player.hooks.onAttack.add(instance, (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (attack.id !== attackId || attack.type !== 'secondary') return
+			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 
 			if (coinFlip[0] === 'heads') {
 				attack.addDamage(this.id, this.secondary.damage)

--- a/common/cards/default/hermits/ethoslab-rare.ts
+++ b/common/cards/default/hermits/ethoslab-rare.ts
@@ -34,9 +34,15 @@ class EthosLabRareHermitCard extends HermitCard {
 
 		player.hooks.onAttack.add(instance, (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.target) return
+			if (
+				attack.id !== attackId ||
+				attack.type !== 'secondary' ||
+				!attack.target ||
+				!attack.attacker
+			)
+				return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 
 			if (coinFlip[0] !== 'heads') return
 

--- a/common/cards/default/hermits/ethoslab-ultra-rare.ts
+++ b/common/cards/default/hermits/ethoslab-ultra-rare.ts
@@ -32,9 +32,9 @@ class EthosLabUltraRareHermitCard extends HermitCard {
 
 		player.hooks.onAttack.add(instance, (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (attack.id !== attackId || attack.type !== 'secondary') return
+			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id, 3)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard, 3)
 			const headsAmount = coinFlip.filter((flip) => flip === 'heads').length
 			attack.addDamage(this.id, headsAmount * 20)
 		})

--- a/common/cards/default/hermits/falsesymmetry-rare.ts
+++ b/common/cards/default/hermits/falsesymmetry-rare.ts
@@ -33,9 +33,9 @@ class FalseSymmetryRareHermitCard extends HermitCard {
 
 		player.hooks.onAttack.add(instance, (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (attack.id !== attackId || attack.type !== 'secondary') return
+			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 
 			if (coinFlip[0] === 'tails') return
 			const attacker = attack.attacker

--- a/common/cards/default/hermits/grian-rare.ts
+++ b/common/cards/default/hermits/grian-rare.ts
@@ -49,9 +49,9 @@ class GrianRareHermitCard extends HermitCard {
 
 		player.hooks.afterAttack.add(instance, (attack) => {
 			if (attack.id !== this.getInstanceKey(instance)) return
-			if (attack.type !== 'primary') return
+			if (attack.type !== 'primary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 
 			if (coinFlip[0] === 'tails') return
 

--- a/common/cards/default/hermits/joehills-rare.ts
+++ b/common/cards/default/hermits/joehills-rare.ts
@@ -38,13 +38,13 @@ class JoeHillsRareHermitCard extends HermitCard {
 
 		player.hooks.onAttack.add(instance, (attack) => {
 			if (attack.id !== this.getInstanceKey(instance)) return
-			if (!attack.attacker || attack.type !== 'secondary') return
+			if (!attack.attacker || attack.type !== 'secondary' || !attack.attacker) return
 
 			if (game.state.statusEffects.some((effect) => effect.statusEffectId === 'used-clock')) {
 				return
 			}
 
-			const coinFlip = flipCoin(player, this.id, 1)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard, 1)
 			if (coinFlip[0] !== 'heads') return
 
 			// This will tell us to block actions at the start of our next turn

--- a/common/cards/default/hermits/mumbojumbo-rare.ts
+++ b/common/cards/default/hermits/mumbojumbo-rare.ts
@@ -36,9 +36,14 @@ class MumboJumboRareHermitCard extends HermitCard {
 		const {player} = pos
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== this.getInstanceKey(instance) || attack.type !== 'secondary') return
+			if (
+				attack.id !== this.getInstanceKey(instance) ||
+				attack.type !== 'secondary' ||
+				!attack.attacker
+			)
+				return
 
-			const coinFlip = flipCoin(player, this.id, 2)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard, 2)
 			const headsAmount = coinFlip.filter((flip) => flip === 'heads').length
 			const pranksterAmount = player.board.rows.filter(
 				(row, index) =>

--- a/common/cards/default/hermits/pearlescentmoon-rare.ts
+++ b/common/cards/default/hermits/pearlescentmoon-rare.ts
@@ -34,13 +34,19 @@ class PearlescentMoonRareHermitCard extends HermitCard {
 		player.custom[status] = 'none'
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== this.getInstanceKey(instance) || attack.type !== 'secondary') return
+			if (
+				attack.id !== this.getInstanceKey(instance) ||
+				attack.type !== 'secondary' ||
+				!attack.attacker
+			)
+				return
 
 			if (player.custom[status] === 'missed') {
 				player.custom[status] = 'none'
 				return
 			}
 
+			const attacker = attack.attacker.row.hermitCard
 			opponentPlayer.hooks.beforeAttack.add(instance, (attack) => {
 				if (attack.isType('status-effect', 'effect') || attack.isBacklash) return
 
@@ -48,7 +54,7 @@ class PearlescentMoonRareHermitCard extends HermitCard {
 
 				// Only flip a coin once
 				if (!hasFlipped) {
-					const coinFlip = flipCoin(player, this.id, 1, opponentPlayer)
+					const coinFlip = flipCoin(player, attacker, 1, opponentPlayer)
 					player.custom[status] = coinFlip[0]
 				}
 

--- a/common/cards/default/hermits/tinfoilchef-rare.ts
+++ b/common/cards/default/hermits/tinfoilchef-rare.ts
@@ -32,9 +32,9 @@ class TinFoilChefRareHermitCard extends HermitCard {
 
 		player.hooks.onAttack.add(instance, (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (attack.id !== attackId || attack.type !== 'secondary') return
+			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 			if (coinFlip[0] === 'tails') return
 
 			const drawCard = player.pile.shift()

--- a/common/cards/default/hermits/tinfoilchef-ultra-rare.ts
+++ b/common/cards/default/hermits/tinfoilchef-ultra-rare.ts
@@ -35,7 +35,7 @@ class TinFoilChefUltraRareHermitCard extends HermitCard {
 
 		player.hooks.beforeAttack.add(instance, (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (attack.id !== attackId || attack.type !== 'secondary') return
+			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.attacker) return
 
 			if (opponentPlayer.board.activeRow === null) return 'NO'
 			const opponentActiveRow = opponentPlayer.board.rows[opponentPlayer.board.activeRow]
@@ -45,7 +45,7 @@ class TinFoilChefUltraRareHermitCard extends HermitCard {
 			const limit = player.custom[this.getInstanceKey(instance)] || {}
 			if (limit[opponentActiveRow.hermitCard.cardInstance]) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 			if (coinFlip[0] === 'tails') return
 
 			limit[opponentActiveRow.hermitCard.cardInstance] = true

--- a/common/cards/default/hermits/vintagebeef-rare.ts
+++ b/common/cards/default/hermits/vintagebeef-rare.ts
@@ -32,9 +32,14 @@ class VintageBeefRareHermitCard extends HermitCard {
 		const {player} = pos
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== this.getInstanceKey(instance) || attack.type !== 'secondary') return
+			if (
+				attack.id !== this.getInstanceKey(instance) ||
+				attack.type !== 'secondary' ||
+				!attack.attacker
+			)
+				return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 			if (coinFlip[0] !== 'heads') return
 
 			player.board.rows.forEach((row) => {

--- a/common/cards/default/hermits/xisumavoid-rare.ts
+++ b/common/cards/default/hermits/xisumavoid-rare.ts
@@ -34,9 +34,15 @@ class XisumavoidRareHermitCard extends HermitCard {
 
 		player.hooks.onAttack.add(instance, (attack) => {
 			const attackId = this.getInstanceKey(instance)
-			if (attack.id !== attackId || attack.type !== 'secondary' || !attack.target) return
+			if (
+				attack.id !== attackId ||
+				attack.type !== 'secondary' ||
+				!attack.target ||
+				!attack.attacker
+			)
+				return
 
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, attack.attacker.row.hermitCard)
 
 			if (coinFlip[0] !== 'heads') return
 

--- a/common/cards/default/hermits/zedaphplays-rare.ts
+++ b/common/cards/default/hermits/zedaphplays-rare.ts
@@ -34,9 +34,10 @@ class ZedaphPlaysRareHermitCard extends HermitCard {
 		const coinFlipResult = this.getInstanceKey(instance, 'coinFlipResult')
 
 		player.hooks.onAttack.add(instance, (attack) => {
-			if (attack.id !== instanceKey || attack.type !== 'primary') return
+			if (attack.id !== instanceKey || attack.type !== 'primary' || !attack.attacker) return
 
-			const coinFlip = flipCoin(player, this.id)
+			const attacker = attack.attacker.row.hermitCard
+			const coinFlip = flipCoin(player, attacker)
 			if (coinFlip[0] !== 'heads') return
 
 			opponentPlayer.hooks.beforeAttack.add(instance, (attack) => {
@@ -45,7 +46,7 @@ class ZedaphPlaysRareHermitCard extends HermitCard {
 
 				// No need to flip a coin for multiple attacks
 				if (!player.custom[coinFlipResult]) {
-					const coinFlip = flipCoin(player, this.id, 1, opponentPlayer)
+					const coinFlip = flipCoin(player, attacker, 1, opponentPlayer)
 					player.custom[coinFlipResult] = coinFlip[0]
 				}
 

--- a/common/cards/default/single-use/fortune.ts
+++ b/common/cards/default/single-use/fortune.ts
@@ -22,7 +22,7 @@ class FortuneSingleUseCard extends SingleUseCard {
 		const {player} = pos
 
 		player.hooks.onApply.add(instance, () => {
-			player.hooks.onCoinFlip.add(instance, (id, coinFlips) => {
+			player.hooks.onCoinFlip.add(instance, (card, coinFlips) => {
 				for (let i = 0; i < coinFlips.length; i++) {
 					coinFlips[i] = 'heads'
 				}

--- a/common/cards/default/single-use/invisibility-potion.ts
+++ b/common/cards/default/single-use/invisibility-potion.ts
@@ -24,7 +24,7 @@ class InvisibilityPotionSingleUseCard extends SingleUseCard {
 		const usedKey = this.getInstanceKey(instance, 'used')
 
 		player.hooks.onApply.add(instance, () => {
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, {cardId: this.id, cardInstance: instance})
 			const multiplier = coinFlip[0] === 'heads' ? 0 : 2
 
 			opponentPlayer.hooks.beforeAttack.add(instance, (attack) => {

--- a/common/cards/default/single-use/spyglass.ts
+++ b/common/cards/default/single-use/spyglass.ts
@@ -24,7 +24,7 @@ class SpyglassSingleUseCard extends SingleUseCard {
 		const {player, opponentPlayer} = pos
 
 		player.hooks.onApply.add(instance, () => {
-			const coinFlip = flipCoin(player, this.id)
+			const coinFlip = flipCoin(player, {cardId: this.id, cardInstance: instance})
 			const canDiscard = coinFlip[0] === 'heads' && opponentPlayer.hand.length > 0
 
 			game.addModalRequest({

--- a/common/models/battle-log.ts
+++ b/common/models/battle-log.ts
@@ -199,11 +199,13 @@ export class BattleLog {
 	}
 
 	public async addCoinFlipEntry(coinFlips: Array<CurrentCoinFlipT>) {
-		const otherPlayer = this.game.currentPlayer.playerName
-
 		if (coinFlips.length === 0) return
 		for (const coinFlip of coinFlips) {
 			const cardName = CARDS[coinFlip.cardId].name
+
+			const otherPlayer = coinFlip.opponentFlip
+				? this.game.opponentPlayer.playerName
+				: this.game.currentPlayer.playerName
 
 			const heads = coinFlip.tosses.filter((flip) => flip === 'heads').length
 			const tails = coinFlip.tosses.filter((flip) => flip === 'tails').length
@@ -227,8 +229,8 @@ export class BattleLog {
 
 			if (HERMIT_CARDS[coinFlip.cardId]) {
 				entry.description = [
-					this.format(`Your `, 'plain', 'player'),
-					this.format(`${otherPlayer}'s `, 'plain', 'opponent'),
+					this.format(`Your `, 'plain', coinFlip.opponentFlip ? 'opponent' : 'player'),
+					this.format(`${otherPlayer}'s `, 'plain', coinFlip.opponentFlip ? 'player' : 'opponent'),
 					this.format(`${cardName} `, coinFlip.opponentFlip ? 'opponent' : 'player'),
 					this.format(description_body + 'their attack', 'plain'),
 				]

--- a/common/status-effects/badomen.ts
+++ b/common/status-effects/badomen.ts
@@ -31,13 +31,15 @@ class BadOmenStatusEffect extends StatusEffect {
 				removeStatusEffect(game, pos, statusEffectInfo.statusEffectInstance)
 		})
 
-		player.hooks.onCoinFlip.add(statusEffectInfo.statusEffectInstance, (id, coinFlips) => {
+		player.hooks.onCoinFlip.addBefore(statusEffectInfo.statusEffectInstance, (card, coinFlips) => {
 			const targetPos = getBasicCardPos(game, statusEffectInfo.targetInstance)
-			if (player.board.activeRow !== targetPos?.rowIndex) return coinFlips
 
-			// If they are not flipping on their turn, don't modify
+			// Only modify when the target hermit is "flipping"
 			const {currentPlayer} = game
-			if (currentPlayer.id !== player.id && id !== targetPos.row?.hermitCard?.cardId) {
+			if (
+				statusEffectInfo.targetInstance !== card.cardInstance &&
+				(currentPlayer.id !== player.id || player.board.activeRow !== targetPos?.rowIndex)
+			) {
 				return coinFlips
 			}
 
@@ -54,10 +56,10 @@ class BadOmenStatusEffect extends StatusEffect {
 	}
 
 	override onRemoval(game: GameModel, statusEffectInfo: StatusEffectT, pos: CardPosModel) {
-		const {player} = pos
+		const {player, opponentPlayer} = pos
 		player.hooks.onCoinFlip.remove(statusEffectInfo.statusEffectInstance)
 		player.hooks.onHermitDeath.remove(statusEffectInfo.statusEffectInstance)
-		player.hooks.onTurnStart.remove(statusEffectInfo.statusEffectInstance)
+		opponentPlayer.hooks.onTurnStart.remove(statusEffectInfo.statusEffectInstance)
 	}
 }
 

--- a/common/types/game-state.ts
+++ b/common/types/game-state.ts
@@ -149,8 +149,8 @@ export type PlayerState = {
 		/** Hook called at the end of the turn */
 		onTurnEnd: GameHook<(drawCards: Array<CardT | null>) => void>
 
-		/** Hook called the player flips a coin */
-		onCoinFlip: GameHook<(id: string, coinFlips: Array<CoinFlipT>) => Array<CoinFlipT>>
+		/** Hook called when the player flips a coin */
+		onCoinFlip: GameHook<(card: CardT, coinFlips: Array<CoinFlipT>) => Array<CoinFlipT>>
 
 		// @TODO eventually to simplify a lot more code this could potentially be called whenever anything changes the row, using a helper.
 		/** Hook called before the active row is changed. Returns whether or not the change can be completed. */

--- a/common/utils/coinFlips.ts
+++ b/common/utils/coinFlips.ts
@@ -1,17 +1,19 @@
 import {DEBUG_CONFIG} from '../config'
-import {CoinFlipT, PlayerState} from '../types/game-state'
+import {CardT, CoinFlipT, PlayerState} from '../types/game-state'
 import {CARDS} from '../cards'
 
 export function flipCoin(
 	playerTossingCoin: PlayerState,
-	cardId: string,
+	card: CardT,
 	times: number = 1,
 	currentPlayer: PlayerState | null = null
 ) {
 	const forceHeads = DEBUG_CONFIG.forceCoinFlip
 	const activeRowIndex = playerTossingCoin.board.activeRow
 	if (activeRowIndex === null) {
-		console.log(`${cardId} attempted to flip coin with no active row!, that shouldn't be possible`)
+		console.log(
+			`${card.cardId} attempted to flip coin with no active row!, that shouldn't be possible`
+		)
 		return []
 	}
 
@@ -25,12 +27,12 @@ export function flipCoin(
 		}
 	}
 
-	playerTossingCoin.hooks.onCoinFlip.call(cardId, coinFlips)
+	playerTossingCoin.hooks.onCoinFlip.call(card, coinFlips)
 
-	const name = CARDS[cardId].name
+	const name = CARDS[card.cardId].name
 	const player = currentPlayer || playerTossingCoin
 	player.coinFlips.push({
-		cardId: cardId,
+		cardId: card.cardId,
 		opponentFlip: currentPlayer !== null,
 		name: !currentPlayer ? name : 'Opponent ' + name,
 		tosses: coinFlips,

--- a/server/src/utils/state-gen.ts
+++ b/server/src/utils/state-gen.ts
@@ -241,7 +241,7 @@ export function getPlayerState(player: PlayerModel): PlayerState {
 			onHermitDeath: new GameHook<(hermitPos: CardPosModel) => void>(),
 			onTurnStart: new GameHook<() => void>(),
 			onTurnEnd: new GameHook<(drawCards: Array<CardT>) => void>(),
-			onCoinFlip: new GameHook<(id: string, coinFlips: Array<CoinFlipT>) => Array<CoinFlipT>>(),
+			onCoinFlip: new GameHook<(card: CardT, coinFlips: Array<CoinFlipT>) => Array<CoinFlipT>>(),
 			beforeActiveRowChange: new GameHook<
 				(oldRow: number | null, newRow: number | null) => boolean
 			>(),


### PR DESCRIPTION
- Fixes Bad Omen having priority over a Fortune when an opponent plays BO immediately after
- Fixes Bad Omen not applying to Cleo/Ren imitating attacks with opponent flips (e.g. Aussie Ping)
- Fixes battle log showing wrong card or player for some coin flips

*Note: If Pearl uses Aussie Ping w/ Chorus Fruit, the opponent **can** miss if the new hermit has Bad Omen but the original Pearl does not when flipping*