### PR TITLE
Fixes health reducing after Ladder

### DIFF
--- a/common/cards/advent-of-tcg/effects/brewing-stand.ts
+++ b/common/cards/advent-of-tcg/effects/brewing-stand.ts
@@ -1,6 +1,7 @@
 import EffectCard from '../../base/effect-card'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
+import {healRow} from '../../../utils/board'
 import {flipCoin} from '../../../utils/coinFlips'
 import {discardCard} from '../../../utils/movement'
 import {HERMIT_CARDS} from '../..'
@@ -45,7 +46,7 @@ class BrewingStandEffectCard extends EffectCard {
 					if (!hermitCard || !playerRow.health) return 'SUCCESS'
 					const hermitInfo = HERMIT_CARDS[hermitCard.cardId]
 					if (hermitInfo) {
-						playerRow.health = Math.min(playerRow.health + 50, hermitInfo.health)
+						healRow(playerRow, 50)
 					} else {
 						// Armor Stand
 						playerRow.health += 50

--- a/common/cards/advent-of-tcg/hermits/grianch-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/grianch-rare.ts
@@ -2,8 +2,9 @@ import HermitCard from '../../base/hermit-card'
 import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
-import {getNonEmptyRows} from '../../../utils/board'
+import {getNonEmptyRows, healRow} from '../../../utils/board'
 import {flipCoin} from '../../../utils/coinFlips'
+import {RowStateWithHermit} from '../../../types/game-state'
 
 class GrianchRareHermitCard extends HermitCard {
 	constructor() {
@@ -79,10 +80,7 @@ class GrianchRareHermitCard extends HermitCard {
 					const hermitInfo = HERMIT_CARDS[hermitId]
 					if (hermitInfo) {
 						// Heal
-						pickedPlayer.board.rows[rowIndex].health = Math.min(
-							hermitHealth + 40,
-							hermitInfo.health // Max health
-						)
+						healRow(pickedPlayer.board.rows[rowIndex] as RowStateWithHermit, 40)
 					} else {
 						// Armor Stand
 						pickedPlayer.board.rows[rowIndex].health = hermitHealth + 40

--- a/common/cards/advent-of-tcg/hermits/pharaoh-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/pharaoh-rare.ts
@@ -1,7 +1,7 @@
 import {CARDS, HERMIT_CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {getActiveRow, getNonEmptyRows} from '../../../utils/board'
+import {getActiveRow, getNonEmptyRows, healRow} from '../../../utils/board'
 import {flipCoin} from '../../../utils/coinFlips'
 import HermitCard from '../../base/hermit-card'
 
@@ -105,10 +105,7 @@ class PharaohRareHermitCard extends HermitCard {
 			const hermitInfo = HERMIT_CARDS[pickedRow.hermitCard.cardId]
 			if (hermitInfo) {
 				// Heal
-				pickedRow.health = Math.min(
-					pickedRow.health + attack.calculateDamage(),
-					hermitInfo.health // Max health
-				)
+				healRow(pickedRow, attack.calculateDamage())
 			}
 		})
 

--- a/common/cards/alter-egos/hermits/potatoboy-rare.ts
+++ b/common/cards/alter-egos/hermits/potatoboy-rare.ts
@@ -2,6 +2,7 @@ import HermitCard from '../../base/hermit-card'
 import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
+import {healRow} from '../../../utils/board'
 class PotatoBoyRareHermitCard extends HermitCard {
 	constructor() {
 		super({
@@ -43,7 +44,7 @@ class PotatoBoyRareHermitCard extends HermitCard {
 				if (!row.hermitCard) return
 				const hermitInfo = HERMIT_CARDS[row.hermitCard.cardId]
 				if (hermitInfo) {
-					row.health = Math.min(row.health + 40, hermitInfo.health)
+					healRow(row, 40)
 				}
 			})
 		})

--- a/common/cards/alter-egos/single-use/splash-potion-of-healing-ii.ts
+++ b/common/cards/alter-egos/single-use/splash-potion-of-healing-ii.ts
@@ -1,5 +1,6 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
+import {healRow} from '../../../utils/board'
 import SingleUseCard from '../../base/single-use-card'
 import {HERMIT_CARDS} from '../../index'
 
@@ -26,7 +27,7 @@ class SplashPotionOfHealingIISingleUseCard extends SingleUseCard {
 				if (!row.hermitCard) continue
 				const hermitInfo = HERMIT_CARDS[row.hermitCard.cardId]
 				if (hermitInfo) {
-					row.health = Math.min(row.health + 30, hermitInfo.health)
+					healRow(row, 30)
 				}
 			}
 		})

--- a/common/cards/default/hermits/falsesymmetry-rare.ts
+++ b/common/cards/default/hermits/falsesymmetry-rare.ts
@@ -1,6 +1,7 @@
 import {HERMIT_CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
+import {healRow} from '../../../utils/board'
 import {flipCoin} from '../../../utils/coinFlips'
 import HermitCard from '../../base/hermit-card'
 
@@ -43,7 +44,7 @@ class FalseSymmetryRareHermitCard extends HermitCard {
 
 			// Heal 40hp
 			const hermitInfo = HERMIT_CARDS[attacker.row.hermitCard.cardId]
-			attacker.row.health = Math.min(attacker.row.health + 40, hermitInfo.health)
+			healRow(attacker.row, 40)
 		})
 	}
 

--- a/common/cards/default/hermits/keralis-rare.ts
+++ b/common/cards/default/hermits/keralis-rare.ts
@@ -2,7 +2,7 @@ import HermitCard from '../../base/hermit-card'
 import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
-import {getNonEmptyRows} from '../../../utils/board'
+import {getNonEmptyRows, healRow} from '../../../utils/board'
 
 class KeralisRareHermitCard extends HermitCard {
 	constructor() {
@@ -93,10 +93,7 @@ class KeralisRareHermitCard extends HermitCard {
 			const hermitInfo = HERMIT_CARDS[pickedRow.hermitCard.cardId]
 			if (hermitInfo) {
 				// Heal
-				pickedRow.health = Math.min(
-					pickedRow.health + 100,
-					hermitInfo.health // Max health
-				)
+				healRow(pickedRow, 100)
 			}
 
 			delete player.custom[playerKey]

--- a/common/cards/default/single-use/golden-apple.ts
+++ b/common/cards/default/single-use/golden-apple.ts
@@ -3,7 +3,7 @@ import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {isActive} from '../../../utils/game'
-import {applySingleUse, getNonEmptyRows} from '../../../utils/board'
+import {applySingleUse, getNonEmptyRows, healRow} from '../../../utils/board'
 
 class GoldenAppleSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -62,7 +62,7 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 					[`${hermitInfo.name} `, 'player'],
 				])
 
-				row.health = Math.min(row.health + 100, hermitInfo.health)
+				healRow(row, 100)
 
 				return 'SUCCESS'
 			},

--- a/common/cards/default/single-use/instant-health-ii.ts
+++ b/common/cards/default/single-use/instant-health-ii.ts
@@ -2,7 +2,7 @@ import SingleUseCard from '../../base/single-use-card'
 import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
-import {applySingleUse, getNonEmptyRows} from '../../../utils/board'
+import {applySingleUse, getNonEmptyRows, healRow} from '../../../utils/board'
 import {isActive} from '../../../utils/game'
 
 class InstantHealthIISingleUseCard extends SingleUseCard {
@@ -58,7 +58,7 @@ class InstantHealthIISingleUseCard extends SingleUseCard {
 					[`${hermitInfo.name} `, 'player'],
 				])
 
-				row.health = Math.min(row.health + 60, hermitInfo.health)
+				healRow(row, 60)
 
 				return 'SUCCESS'
 			},

--- a/common/cards/default/single-use/instant-health.ts
+++ b/common/cards/default/single-use/instant-health.ts
@@ -2,7 +2,7 @@ import SingleUseCard from '../../base/single-use-card'
 import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
-import {applySingleUse, getNonEmptyRows} from '../../../utils/board'
+import {applySingleUse, getNonEmptyRows, healRow} from '../../../utils/board'
 
 class InstantHealthSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -57,7 +57,7 @@ class InstantHealthSingleUseCard extends SingleUseCard {
 					[`${hermitInfo.name} `, 'player'],
 				])
 
-				row.health = Math.min(row.health + 30, hermitInfo.health)
+				healRow(row, 30)
 
 				return 'SUCCESS'
 			},

--- a/common/cards/default/single-use/splash-potion-of-healing.ts
+++ b/common/cards/default/single-use/splash-potion-of-healing.ts
@@ -1,5 +1,6 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
+import {healRow} from '../../../utils/board'
 import SingleUseCard from '../../base/single-use-card'
 import {HERMIT_CARDS} from '../../index'
 
@@ -26,7 +27,7 @@ class SplashPotionOfHealingSingleUseCard extends SingleUseCard {
 				if (!row.hermitCard) continue
 				const hermitInfo = HERMIT_CARDS[row.hermitCard.cardId]
 				if (hermitInfo) {
-					row.health = Math.min(row.health + 20, hermitInfo.health)
+					healRow(row, 20)
 				}
 			}
 		})

--- a/common/status-effects/melody.ts
+++ b/common/status-effects/melody.ts
@@ -1,7 +1,7 @@
 import StatusEffect from './status-effect'
 import {GameModel} from '../models/game-model'
 import {CardPosModel, getBasicCardPos} from '../models/card-pos-model'
-import {removeStatusEffect} from '../utils/board'
+import {healRow, removeStatusEffect} from '../utils/board'
 import {StatusEffectT} from '../types/game-state'
 import {HERMIT_CARDS} from '../cards'
 
@@ -36,7 +36,7 @@ class MelodyStatusEffect extends StatusEffect {
 
 			const hermitInfo = HERMIT_CARDS[targetPos.row.hermitCard.cardId]
 			if (hermitInfo) {
-				targetPos.row.health = Math.min(targetPos.row.health + 10, hermitInfo.health)
+				healRow(targetPos.row, 10)
 			}
 		})
 

--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -19,7 +19,7 @@ function executeAttack(attack: AttackModel) {
 	const currentHealth = row.health
 	let maxHealth = currentHealth // Armor Stand
 	if (targetHermitInfo) {
-		maxHealth = targetHermitInfo.health
+		maxHealth = Math.max(targetHermitInfo.health, maxHealth)
 	}
 
 	const weaknessAttack = createWeaknessAttack(attack)

--- a/common/utils/board.ts
+++ b/common/utils/board.ts
@@ -1,4 +1,4 @@
-import {CARDS, ITEM_CARDS} from '../cards'
+import {CARDS, HERMIT_CARDS, ITEM_CARDS} from '../cards'
 import {STATUS_EFFECT_CLASSES} from '../status-effects'
 import {CardPosModel, getCardPos} from '../models/card-pos-model'
 import {GameModel} from '../models/game-model'
@@ -204,4 +204,12 @@ export function canAttachToCard(
 	if (!cardInfo.canAttachToCard(game, cardAttachingPos)) return false
 
 	return true
+}
+
+export function healRow(row: RowStateWithHermit, amount: number) {
+	const hermitInfo = HERMIT_CARDS[row.hermitCard.cardId]
+
+	if (!hermitInfo || amount <= 0) return
+
+	row.health = Math.min(Math.max(row.health, hermitInfo.health), row.health + amount)
 }


### PR DESCRIPTION
Adds `healRow` function to "common/utils/board.ts"
- Fixes where healing can reduce health after using Ladder
_Rare False uses Supremacy after Ladder and clamps health on flipping heads_
- Fixes hermit taking extra damage if first attack is less than the extra health from Ladder
_A 250hp max Hermit ladders to get 300hp, if the first attack executed deals less than 50dmg then health would be set to 250_