### PR TITLE
Change weakness to only count attacks that have a multiplier of 0 as a missed attack

### DIFF
--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -254,8 +254,8 @@ export function isTargetingPos(attack: AttackModel, pos: CardPosModel | RowPos):
 
 function createWeaknessAttack(attack: AttackModel): AttackModel | null {
 	if (attack.createWeakness === 'never') return null
+	if (attack.getDamage() * attack.getDamageMultiplier() === 0) return null
 
-	if (attack.calculateDamage() === 0) return null
 	const attacker = attack.getAttacker()
 	const target = attack.getTarget()
 	const attackId = attack.id


### PR DESCRIPTION
I first implemented weakness slightly differently, but after discussing it with the community decided to change it. Now, if an attack is completely negated by armor the weakness damage will still be added, as long as it was not multiplied to 0, or had a base damage of 0 without the damage reduction.

The actual circumstances where this change matters are pretty small, so I doubt most people would even notice a difference, but I do think this makes more sense.