### PR TITLE
HC-TCG Online Update v0.6.41 - The Pack of Wolves Update

### DIFF
--- a/client/src/app/game/modals/unmet-condition-modal.tsx
+++ b/client/src/app/game/modals/unmet-condition-modal.tsx
@@ -20,7 +20,7 @@ function UnmetCondition({closeModal, info}: Props) {
 	return (
 		<Modal title="Unmet Condition" closeModal={closeModal}>
 			<div className={css.confirmModal}>
-				<div className={css.description}>You can't play this card at the moment.</div>
+				<div className={css.description}>You can't play this card in that slot at the moment.</div>
 				<div className={css.options}>
 					<Button onClick={handleOk}>Okay</Button>
 				</div>

--- a/common/cards/alter-egos/hermits/helsknight-rare.ts
+++ b/common/cards/alter-egos/hermits/helsknight-rare.ts
@@ -43,7 +43,7 @@ class HelsknightRareHermitCard extends HermitCard {
 				const coinFlip = flipCoin(player, attackerHermit, 1, opponentPlayer)
 
 				if (coinFlip[0] == 'heads') {
-					moveCardToHand(game, opponentPlayer.board.singleUseCard, true)
+					moveCardToHand(game, opponentPlayer.board.singleUseCard, player)
 					opponentPlayer.board.singleUseCardUsed = false
 				}
 			})

--- a/common/cards/alter-egos/single-use/ladder.ts
+++ b/common/cards/alter-egos/single-use/ladder.ts
@@ -2,7 +2,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {applySingleUse, getSlotPos} from '../../../utils/board'
 import {isCardType} from '../../../utils/cards'
-import {swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
 
 class LadderSingleUseCard extends SingleUseCard {
@@ -24,6 +24,8 @@ class LadderSingleUseCard extends SingleUseCard {
 		const playerBoard = pos.player.board
 		const activeRowIndex = playerBoard.activeRow
 		if (activeRowIndex === null) return 'NO'
+		const activeRow = playerBoard.rows[activeRowIndex]
+		if (!activeRow.hermitCard) return 'NO'
 
 		const adjacentRowsIndex = [activeRowIndex - 1, activeRowIndex + 1].filter(
 			(index) => index >= 0 && index < playerBoard.rows.length
@@ -31,7 +33,11 @@ class LadderSingleUseCard extends SingleUseCard {
 		for (const index of adjacentRowsIndex) {
 			const row = playerBoard.rows[index]
 			if (!isCardType(row.hermitCard, 'hermit')) continue
-			if (row.hermitCard !== null) return 'YES'
+			const hermitSlot = getSlotPos(pos.player, index, 'hermit')
+			if (!canAttachToSlot(game, hermitSlot, activeRow.hermitCard)) continue
+			if (!row.hermitCard) continue
+
+			return 'YES'
 		}
 
 		return 'NO'

--- a/common/cards/alter-egos/single-use/ladder.ts
+++ b/common/cards/alter-egos/single-use/ladder.ts
@@ -34,7 +34,7 @@ class LadderSingleUseCard extends SingleUseCard {
 			const row = playerBoard.rows[index]
 			if (!isCardType(row.hermitCard, 'hermit')) continue
 			const hermitSlot = getSlotPos(pos.player, index, 'hermit')
-			if (!canAttachToSlot(game, hermitSlot, activeRow.hermitCard)) continue
+			if (canAttachToSlot(game, hermitSlot, activeRow.hermitCard) !== 'YES') continue
 			if (!row.hermitCard) continue
 
 			return 'YES'

--- a/common/cards/alter-egos/single-use/ladder.ts
+++ b/common/cards/alter-egos/single-use/ladder.ts
@@ -1,7 +1,7 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {SlotPos} from '../../../types/cards'
-import {applySingleUse} from '../../../utils/board'
+import {applySingleUse, getSlotPos} from '../../../utils/board'
 import {isCardType} from '../../../utils/cards'
 import {swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
@@ -62,7 +62,6 @@ class LadderSingleUseCard extends SingleUseCard {
 				)
 				if (!adjacentRowsIndex.includes(pickedIndex)) return 'FAILURE_INVALID_SLOT'
 
-				const activeRow = player.board.rows[activeRowIndex]
 				const row = player.board.rows[pickedIndex]
 				if (!row || !row.health) return 'FAILURE_INVALID_SLOT'
 
@@ -70,24 +69,10 @@ class LadderSingleUseCard extends SingleUseCard {
 				applySingleUse(game, [])
 
 				// Swap slots
-				const activePos: SlotPos = {
-					rowIndex: activeRowIndex,
-					row: activeRow,
-					slot: {
-						index: 0,
-						type: 'hermit',
-					},
-				}
-				const inactivePos: SlotPos = {
-					rowIndex: pickedIndex,
-					row,
-					slot: {
-						index: 0,
-						type: 'hermit',
-					},
-				}
-
+				const activePos = getSlotPos(player, activeRowIndex, 'hermit')
+				const inactivePos = getSlotPos(player, pickedIndex, 'hermit')
 				swapSlots(game, activePos, inactivePos, true)
+				
 				game.changeActiveRow(player, pickedIndex)
 
 				return 'SUCCESS'

--- a/common/cards/alter-egos/single-use/ladder.ts
+++ b/common/cards/alter-egos/single-use/ladder.ts
@@ -1,6 +1,5 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {SlotPos} from '../../../types/cards'
 import {applySingleUse, getSlotPos} from '../../../utils/board'
 import {isCardType} from '../../../utils/cards'
 import {swapSlots} from '../../../utils/movement'
@@ -72,7 +71,7 @@ class LadderSingleUseCard extends SingleUseCard {
 				const activePos = getSlotPos(player, activeRowIndex, 'hermit')
 				const inactivePos = getSlotPos(player, pickedIndex, 'hermit')
 				swapSlots(game, activePos, inactivePos, true)
-				
+
 				game.changeActiveRow(player, pickedIndex)
 
 				return 'SUCCESS'

--- a/common/cards/alter-egos/single-use/piston.ts
+++ b/common/cards/alter-egos/single-use/piston.ts
@@ -6,6 +6,7 @@ import {
 	applySingleUse,
 	canAttachToCard,
 	getActiveRowPos,
+	getSlotPos,
 	isRowEmpty,
 	rowHasEmptyItemSlot,
 } from '../../../utils/board'
@@ -109,24 +110,8 @@ class PistonSingleUseCard extends SingleUseCard {
 				if (!canAttachToCard(game, pickedRow.hermitCard, itemCard)) return 'FAILURE_INVALID_SLOT'
 
 				// Move the item
-				const itemPos: SlotPos = {
-					rowIndex: firstRowIndex,
-					row: firstRow,
-					slot: {
-						index: itemIndex,
-						type: 'item',
-					},
-				}
-
-				const targetPos: SlotPos = {
-					rowIndex: pickedIndex,
-					row: pickedRow,
-					slot: {
-						index: pickResult.slot.index,
-						type: 'item',
-					},
-				}
-
+				const itemPos = getSlotPos(player, firstRowIndex, 'item', itemIndex)
+				const targetPos = getSlotPos(player, pickedIndex, 'item', pickResult.slot.index)
 				swapSlots(game, itemPos, targetPos)
 
 				// Only add the after apply hook here

--- a/common/cards/alter-egos/single-use/piston.ts
+++ b/common/cards/alter-egos/single-use/piston.ts
@@ -1,11 +1,9 @@
 import {CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {SlotPos} from '../../../types/cards'
 import {
 	applySingleUse,
 	canAttachToCard,
-	getActiveRowPos,
 	getSlotPos,
 	isRowEmpty,
 	rowHasEmptyItemSlot,

--- a/common/cards/alter-egos/single-use/target-block.ts
+++ b/common/cards/alter-egos/single-use/target-block.ts
@@ -65,11 +65,6 @@ class TargetBlockSingleUseCard extends SingleUseCard {
 					})
 				})
 
-				opponentPlayer.hooks.onDefence.addBefore(instance, (attack) => {
-					if (attack.isType('status-effect') || attack.isBacklash) return
-					attack.type = 'effect'
-				})
-
 				return 'SUCCESS'
 			},
 		})

--- a/common/cards/base/card.ts
+++ b/common/cards/base/card.ts
@@ -37,6 +37,12 @@ abstract class Card {
 
 	/**
 	 * If the specified slot is empty, can this card be attached there
+	 * 
+	 * YES - Card can be attached to the slot
+	 * 
+	 * NO - This card normally can be attached in the slot but something is preventing it (Shows a popup)
+	 * 
+	 * INVALID - This card can never be attached in the slot - it's an invalid slot
 	 */
 	public abstract canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID'
 

--- a/common/cards/default/effects/diamond-armor.ts
+++ b/common/cards/default/effects/diamond-armor.ts
@@ -10,7 +10,8 @@ class DiamondArmorEffectCard extends EffectCard {
 			numericId: 13,
 			name: 'Diamond Armor',
 			rarity: 'rare',
-			description: 'Prevent up to 30hp damage each turn.',
+			description:
+				'When the Hermit this card is attached to takes damage, reduce that damage by up to 30hp each turn.',
 		})
 	}
 

--- a/common/cards/default/effects/gold-armor.ts
+++ b/common/cards/default/effects/gold-armor.ts
@@ -10,7 +10,8 @@ class GoldArmorEffectCard extends EffectCard {
 			numericId: 29,
 			name: 'Gold Armor',
 			rarity: 'common',
-			description: 'Prevent up to 10hp damage each turn.',
+			description:
+				'When the Hermit this card is attached to takes damage, reduce that damage by up to 10hp each turn.',
 		})
 	}
 

--- a/common/cards/default/effects/iron-armor.ts
+++ b/common/cards/default/effects/iron-armor.ts
@@ -10,7 +10,8 @@ class IronArmorEffectCard extends EffectCard {
 			numericId: 45,
 			name: 'Iron Armor',
 			rarity: 'common',
-			description: 'Prevent up to 20hp damage each turn.',
+			description:
+				'When the Hermit this card is attached to takes damage, reduce that damage by up to 20hp each turn.',
 		})
 	}
 

--- a/common/cards/default/effects/netherite-armor.ts
+++ b/common/cards/default/effects/netherite-armor.ts
@@ -10,7 +10,8 @@ class NetheriteArmorEffectCard extends EffectCard {
 			numericId: 82,
 			name: 'Netherite Armor',
 			rarity: 'ultra_rare',
-			description: 'Prevent up to 40hp damage each turn.',
+			description:
+				'When the Hermit this card is attached to takes damage, reduce that damage by up to 40hp each turn.',
 		})
 	}
 

--- a/common/cards/default/single-use/emerald.ts
+++ b/common/cards/default/single-use/emerald.ts
@@ -1,7 +1,7 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {SlotPos} from '../../../types/cards'
-import {canAttachToCard} from '../../../utils/board'
+import {canAttachToCard, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
@@ -56,25 +56,8 @@ class EmeraldSingleUseCard extends SingleUseCard {
 		player.hooks.onApply.add(instance, () => {
 			if (playerActiveRowIndex === null || opponentActiveRowIndex === null) return
 
-			const opponentActiveRow = opponentPlayer.board.rows[opponentActiveRowIndex]
-			const playerActiveRow = player.board.rows[playerActiveRowIndex]
-
-			const playerSlot: SlotPos = {
-				rowIndex: playerActiveRowIndex,
-				row: playerActiveRow,
-				slot: {
-					index: 0,
-					type: 'effect',
-				},
-			}
-			const opponentSlot: SlotPos = {
-				rowIndex: opponentActiveRowIndex,
-				row: opponentActiveRow,
-				slot: {
-					index: 0,
-					type: 'effect',
-				},
-			}
+			const playerSlot = getSlotPos(player, playerActiveRowIndex, 'effect')
+			const opponentSlot = getSlotPos(opponentPlayer, opponentActiveRowIndex, 'effect')
 
 			swapSlots(game, playerSlot, opponentSlot)
 		})

--- a/common/cards/default/single-use/emerald.ts
+++ b/common/cards/default/single-use/emerald.ts
@@ -33,18 +33,22 @@ class EmeraldSingleUseCard extends SingleUseCard {
 		const playerEffect = playerActiveRow.effectCard
 		const opponentHermit = opponentActiveRow.hermitCard
 		const playerHermit = playerActiveRow.hermitCard
-		
+
 		// If either card can't be placed in the other slot, don't attach
 		const playerEffectSlot = getSlotPos(player, playerActiveRowIndex, 'effect')
 		const opponentEffectSlot = getSlotPos(opponentPlayer, opponentActiveRowIndex, 'effect')
-		if (playerEffect && !canAttachToSlot(game, opponentEffectSlot, playerEffect)) return 'NO'
-		if (opponentEffect && !canAttachToSlot(game, playerEffectSlot, opponentEffect)) return 'NO'
 
-		if (opponentEffect && !canAttachToCard(game, opponentEffect, playerHermit)) return 'NO'
-		if (playerEffect && !canAttachToCard(game, playerEffect, opponentHermit)) return 'NO'
+		if (playerEffect) {
+			if (canAttachToSlot(game, opponentEffectSlot, playerEffect) !== 'YES') return 'NO'
+			if (!canAttachToCard(game, playerEffect, opponentHermit)) return 'NO'
+			if (!isRemovable(playerEffect)) return 'NO'
+		}
 
-		if (opponentEffect && !isRemovable(opponentEffect)) return 'NO'
-		if (playerEffect && !isRemovable(playerEffect)) return 'NO'
+		if (opponentEffect) {
+			if (canAttachToSlot(game, playerEffectSlot, opponentEffect) !== 'YES') return 'NO'
+			if (!canAttachToCard(game, opponentEffect, playerHermit)) return 'NO'
+			if (!isRemovable(opponentEffect)) return 'NO'
+		}
 
 		return 'YES'
 	}

--- a/common/cards/default/single-use/emerald.ts
+++ b/common/cards/default/single-use/emerald.ts
@@ -2,7 +2,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {canAttachToCard, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
-import {swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
 
 class EmeraldSingleUseCard extends SingleUseCard {
@@ -33,12 +33,18 @@ class EmeraldSingleUseCard extends SingleUseCard {
 		const playerEffect = playerActiveRow.effectCard
 		const opponentHermit = opponentActiveRow.hermitCard
 		const playerHermit = playerActiveRow.hermitCard
+		
+		// If either card can't be placed in the other slot, don't attach
+		const playerEffectSlot = getSlotPos(player, playerActiveRowIndex, 'effect')
+		const opponentEffectSlot = getSlotPos(opponentPlayer, opponentActiveRowIndex, 'effect')
+		if (playerEffect && !canAttachToSlot(game, opponentEffectSlot, playerEffect)) return 'NO'
+		if (opponentEffect && !canAttachToSlot(game, playerEffectSlot, opponentEffect)) return 'NO'
 
 		if (opponentEffect && !canAttachToCard(game, opponentEffect, playerHermit)) return 'NO'
 		if (playerEffect && !canAttachToCard(game, playerEffect, opponentHermit)) return 'NO'
 
-		if (opponentEffect) if (!isRemovable(opponentEffect)) return 'NO'
-		if (playerEffect) if (!isRemovable(playerEffect)) return 'NO'
+		if (opponentEffect && !isRemovable(opponentEffect)) return 'NO'
+		if (playerEffect && !isRemovable(playerEffect)) return 'NO'
 
 		return 'YES'
 	}

--- a/common/cards/default/single-use/emerald.ts
+++ b/common/cards/default/single-use/emerald.ts
@@ -1,6 +1,5 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {SlotPos} from '../../../types/cards'
 import {canAttachToCard, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {swapSlots} from '../../../utils/movement'

--- a/common/cards/default/single-use/lead.ts
+++ b/common/cards/default/single-use/lead.ts
@@ -8,6 +8,7 @@ import {
 	getActiveRow,
 	getActiveRowPos,
 	getRowsWithEmptyItemsSlots,
+	getSlotPos,
 	rowHasItem,
 } from '../../../utils/board'
 import {swapSlots} from '../../../utils/movement'
@@ -104,24 +105,8 @@ class LeadSingleUseCard extends SingleUseCard {
 				if (!canAttachToCard(game, row.hermitCard, itemCard)) return 'FAILURE_INVALID_SLOT'
 
 				// Move the item
-				const itemPos: SlotPos = {
-					rowIndex: opponentActivePos.rowIndex,
-					row: opponentActivePos.row,
-					slot: {
-						index: itemIndex,
-						type: 'item',
-					},
-				}
-
-				const targetPos: SlotPos = {
-					rowIndex,
-					row,
-					slot: {
-						index: pickResult.slot.index,
-						type: 'item',
-					},
-				}
-
+				const itemPos = getSlotPos(opponentPlayer, opponentActivePos.rowIndex, 'item', itemIndex)
+				const targetPos = getSlotPos(opponentPlayer, rowIndex, 'item', pickResult.slot.index)
 				swapSlots(game, itemPos, targetPos)
 
 				const cardInfo = CARDS[itemCard!.cardId]

--- a/common/cards/default/single-use/lead.ts
+++ b/common/cards/default/single-use/lead.ts
@@ -1,7 +1,6 @@
 import {CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {SlotPos} from '../../../types/cards'
 import {
 	applySingleUse,
 	canAttachToCard,

--- a/common/cards/default/single-use/mending.ts
+++ b/common/cards/default/single-use/mending.ts
@@ -3,7 +3,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {applySingleUse, canAttachToCard, getActiveRow, getNonEmptyRows, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
-import {discardSingleUse, swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, discardSingleUse, swapSlots} from '../../../utils/movement'
 import singleUseCard from '../../base/single-use-card'
 
 class MendingSingleUseCard extends singleUseCard {
@@ -28,16 +28,15 @@ class MendingSingleUseCard extends singleUseCard {
 		if (!effectCard || !isRemovable(effectCard)) return 'NO'
 
 		// check if there is an empty slot available to move the effect card to
-		const inactiveHermits = getNonEmptyRows(player, true)
-		for (const hermit of inactiveHermits) {
-			if (!hermit) continue
-			const effect = hermit.row.effectCard
-			if (!effect || isRemovable(effect)) return 'YES'
-		}
+		const inactiveRows = getNonEmptyRows(player, true)
+		for (const rowPos of inactiveRows) {
+			if (rowPos.row.effectCard) continue
 
-		// check if the effect card can be attached to any of the inactive hermits
-		for (const hermit of inactiveHermits) {
-			if (canAttachToCard(game, hermit.row.hermitCard, effectCard)) return 'YES'
+			const attachToCard = canAttachToCard(game, rowPos.row.hermitCard, effectCard);
+			const slotPos = getSlotPos(player, rowPos.rowIndex, 'effect')
+			const attachToSlot = canAttachToSlot(game, slotPos, effectCard)
+
+			if (attachToCard && attachToSlot) return 'YES'
 		}
 
 		return 'NO'

--- a/common/cards/default/single-use/mending.ts
+++ b/common/cards/default/single-use/mending.ts
@@ -2,7 +2,7 @@ import {CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {SlotPos} from '../../../types/cards'
-import {applySingleUse, canAttachToCard, getActiveRow, getNonEmptyRows} from '../../../utils/board'
+import {applySingleUse, canAttachToCard, getActiveRow, getNonEmptyRows, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {discardSingleUse, swapSlots} from '../../../utils/movement'
 import singleUseCard from '../../base/single-use-card'
@@ -90,24 +90,8 @@ class MendingSingleUseCard extends singleUseCard {
 				])
 
 				// Move the effect card
-				const sourcePos: SlotPos = {
-					rowIndex: activeRowIndex,
-					row: activeRow,
-					slot: {
-						type: 'effect',
-						index: 0,
-					},
-				}
-
-				const targetPos: SlotPos = {
-					rowIndex,
-					row: player.board.rows[rowIndex],
-					slot: {
-						type: 'effect',
-						index: 0,
-					},
-				}
-
+				const sourcePos = getSlotPos(player, activeRowIndex, 'effect')
+				const targetPos = getSlotPos(player, rowIndex, 'effect')
 				swapSlots(game, sourcePos, targetPos)
 
 				return 'SUCCESS'

--- a/common/cards/default/single-use/mending.ts
+++ b/common/cards/default/single-use/mending.ts
@@ -1,7 +1,6 @@
 import {CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {SlotPos} from '../../../types/cards'
 import {applySingleUse, canAttachToCard, getActiveRow, getNonEmptyRows, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {discardSingleUse, swapSlots} from '../../../utils/movement'

--- a/common/config/debug-config.json
+++ b/common/config/debug-config.json
@@ -1,9 +1,9 @@
 {
 	"disableDeckValidation": false,
-	"extraStartingCards": ["ethoslab_ultra_rare", "target_block", "wolf", "ladder"],
-	"noItemRequirements": true,
-	"forceCoinFlip": true,
-	"oneShotMode": true,
+	"extraStartingCards": [],
+	"noItemRequirements": false,
+	"forceCoinFlip": false,
+	"oneShotMode": false,
 	"disableDamage": false,
 	"disableDeckOut": false,
 	"startWithAllCards": false,

--- a/common/config/debug-config.json
+++ b/common/config/debug-config.json
@@ -1,9 +1,9 @@
 {
 	"disableDeckValidation": false,
-	"extraStartingCards": [],
-	"noItemRequirements": false,
-	"forceCoinFlip": false,
-	"oneShotMode": false,
+	"extraStartingCards": ["ethoslab_ultra_rare", "target_block", "wolf", "ladder"],
+	"noItemRequirements": true,
+	"forceCoinFlip": true,
+	"oneShotMode": true,
 	"disableDamage": false,
 	"disableDeckOut": false,
 	"startWithAllCards": false,

--- a/common/config/server-config.json
+++ b/common/config/server-config.json
@@ -12,7 +12,7 @@
 		"maxDuplicates": 3,
 		"maxDeckCost": 42
 	},
-	"logoSubText": "Unification!",
+	"logoSubText": "Woof woof.",
 	"botUrl": "http://51.83.19.63:8194",
 	"version": "0.6.40"
 }

--- a/common/config/server-config.json
+++ b/common/config/server-config.json
@@ -14,5 +14,5 @@
 	},
 	"logoSubText": "Woof woof.",
 	"botUrl": "http://51.83.19.63:8194",
-	"version": "0.6.40"
+	"version": "0.6.41"
 }

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -11,7 +11,7 @@ import {MessageInfoT} from '../types/chat'
 import {getGameState} from '../utils/state-gen'
 import {ModalRequest, PickRequest} from '../types/server-requests'
 import {BattleLog} from './battle-log'
-import { getSlotPos } from '../utils/board'
+import {getSlotPos} from '../utils/board'
 
 export class GameModel {
 	private internalCreatedTime: number
@@ -158,7 +158,6 @@ export class GameModel {
 		const turnState = this.state.turn
 		const allBlockedActions: TurnActions = []
 		Object.keys(turnState.blockedActions).forEach((sourceId) => {
-			console.log('soucreId: ' + sourceId)
 			if (excludeIds?.includes(sourceId)) return
 
 			const actions = turnState.blockedActions[sourceId]
@@ -255,7 +254,6 @@ export class GameModel {
 
 	/**Helper method to swap the positions of two rows on the board. Returns whether or not the change was successful. */
 	public swapRows(player: PlayerState, oldRow: number, newRow: number): boolean {
-
 		const oldSlotPos = getSlotPos(player, oldRow, 'hermit')
 
 		const results = player.hooks.onSlotChange.call(oldSlotPos)

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -10,7 +10,6 @@ import {
 import {MessageInfoT} from '../types/chat'
 import {getGameState} from '../utils/state-gen'
 import {ModalRequest, PickRequest} from '../types/server-requests'
-import {SlotPos} from '../types/cards'
 import {BattleLog} from './battle-log'
 import { getSlotPos } from '../utils/board'
 

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -12,6 +12,7 @@ import {getGameState} from '../utils/state-gen'
 import {ModalRequest, PickRequest} from '../types/server-requests'
 import {SlotPos} from '../types/cards'
 import {BattleLog} from './battle-log'
+import { getSlotPos } from '../utils/board'
 
 export class GameModel {
 	private internalCreatedTime: number
@@ -255,16 +256,8 @@ export class GameModel {
 
 	/**Helper method to swap the positions of two rows on the board. Returns whether or not the change was successful. */
 	public swapRows(player: PlayerState, oldRow: number, newRow: number): boolean {
-		const oldRowState = player.board.rows[oldRow]
 
-		const oldSlotPos: SlotPos = {
-			rowIndex: oldRow,
-			row: oldRowState,
-			slot: {
-				index: 0,
-				type: 'hermit',
-			},
-		}
+		const oldSlotPos = getSlotPos(player, oldRow, 'hermit')
 
 		const results = player.hooks.onSlotChange.call(oldSlotPos)
 		if (results.includes(false)) return false
@@ -272,6 +265,7 @@ export class GameModel {
 		const activeRowChanged = this.changeActiveRow(player, newRow)
 		if (!activeRowChanged) return false
 
+		const oldRowState = player.board.rows[oldRow]
 		player.board.rows[oldRow] = player.board.rows[newRow]
 		player.board.rows[newRow] = oldRowState
 

--- a/common/types/cards.ts
+++ b/common/types/cards.ts
@@ -55,6 +55,7 @@ export type RowPos = {
 }
 
 export type SlotPos = {
+	player: PlayerState
 	rowIndex: number
 	row: RowState
 	slot: BoardSlot

--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -248,8 +248,8 @@ export function isTargetingPos(attack: AttackModel, pos: CardPosModel | RowPos):
 
 function createWeaknessAttack(attack: AttackModel): AttackModel | null {
 	if (attack.createWeakness === 'never') return null
+	if (attack.getDamage() * attack.getDamageMultiplier() === 0) return null
 
-	if (attack.calculateDamage() === 0) return null
 	const attacker = attack.getAttacker()
 	const target = attack.getTarget()
 	const attackId = attack.id

--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -14,20 +14,14 @@ function executeAttack(attack: AttackModel) {
 	const {row} = target
 	if (!row.hermitCard) return
 
-	const targetHermitInfo = HERMIT_CARDS[row.hermitCard.cardId]
-
 	const currentHealth = row.health
-	let maxHealth = currentHealth // Armor Stand
-	if (targetHermitInfo) {
-		maxHealth = targetHermitInfo.health
-	}
 
 	const weaknessAttack = createWeaknessAttack(attack)
 	if (weaknessAttack) attack.addNewAttack(weaknessAttack)
 
 	// Deduct and clamp health
 	const newHealth = Math.max(currentHealth - attack.calculateDamage(), 0)
-	row.health = Math.min(newHealth, maxHealth)
+	row.health = Math.min(newHealth, currentHealth)
 }
 
 /**

--- a/common/utils/board.ts
+++ b/common/utils/board.ts
@@ -2,7 +2,7 @@ import {CARDS, ITEM_CARDS} from '../cards'
 import {STATUS_EFFECT_CLASSES} from '../status-effects'
 import {CardPosModel, getCardPos} from '../models/card-pos-model'
 import {GameModel} from '../models/game-model'
-import {RowPos} from '../types/cards'
+import {BoardSlotTypeT, RowPos, SlotPos} from '../types/cards'
 import {
 	CardT,
 	StatusEffectT,
@@ -13,22 +13,44 @@ import {
 } from '../types/game-state'
 import {BattleLogFormatT} from '../models/battle-log'
 
-export function getActiveRow(playerState: PlayerState) {
-	if (playerState.board.activeRow === null) return null
-	const row = playerState.board.rows[playerState.board.activeRow]
+export function getActiveRow(player: PlayerState) {
+	if (player.board.activeRow === null) return null
+	const row = player.board.rows[player.board.activeRow]
 	if (!row.hermitCard) return null
 	return row
 }
 
-export function getActiveRowPos(playerState: PlayerState): RowPos | null {
-	const rowIndex = playerState.board.activeRow
+export function getActiveRowPos(player: PlayerState): RowPos | null {
+	const rowIndex = player.board.activeRow
 	if (rowIndex === null) return null
-	const row = playerState.board.rows[rowIndex]
+	const row = player.board.rows[rowIndex]
 	if (!row.hermitCard) return null
 	return {
-		player: playerState,
+		player: player,
 		rowIndex,
 		row,
+	}
+}
+export function getRowPos(cardPos: CardPosModel): RowPos | null {
+	const rowIndex = cardPos.rowIndex
+	if (rowIndex === null) return null
+	const row = cardPos.row
+	if (!row?.hermitCard) return null
+	return {
+		player: cardPos.player,
+		rowIndex,
+		row,
+	}
+}
+
+export function getSlotPos(player: PlayerState, rowIndex: number, type: BoardSlotTypeT, index = 0): SlotPos {
+	return {
+		rowIndex,
+		row: player.board.rows[rowIndex],
+		slot: {
+			type,
+			index,
+		},
 	}
 }
 

--- a/common/utils/board.ts
+++ b/common/utils/board.ts
@@ -45,6 +45,7 @@ export function getRowPos(cardPos: CardPosModel): RowPos | null {
 
 export function getSlotPos(player: PlayerState, rowIndex: number, type: BoardSlotTypeT, index = 0): SlotPos {
 	return {
+		player,
 		rowIndex,
 		row: player.board.rows[rowIndex],
 		slot: {

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -4,6 +4,7 @@ import {CARDS} from '../cards'
 import {CardPosModel, getCardPos} from '../models/card-pos-model'
 import {equalCard} from './cards'
 import {SlotPos} from '../types/cards'
+import {getSlotPos} from './board'
 
 function discardAtPos(pos: CardPosModel) {
 	const {player, row, slot} = pos
@@ -38,14 +39,7 @@ export function discardCard(game: GameModel, card: CardT | null, player?: Player
 	}
 
 	if (pos.row && pos.rowIndex && pos.slot.type !== 'single_use') {
-		const slotPos: SlotPos = {
-			rowIndex: pos.rowIndex,
-			row: pos.row,
-			slot: {
-				index: pos.slot.index,
-				type: pos.slot.type,
-			},
-		}
+		const slotPos = getSlotPos(pos.player, pos.rowIndex, pos.slot.type, pos.slot.index)
 
 		const results = pos.player.hooks.onSlotChange.call(slotPos)
 		if (results.includes(false)) return
@@ -61,7 +55,7 @@ export function discardCard(game: GameModel, card: CardT | null, player?: Player
 
 	if (player !== null) {
 		const discardPlayer = player ? player : pos.player
-	
+
 		discardPlayer.discarded.push({
 			cardId: card.cardId,
 			cardInstance: card.cardInstance,

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -173,7 +173,7 @@ export function getSlotCard(slotPos: SlotPos): CardT | null {
 	return row.itemCards[index]
 }
 
-export function canAttachAtSlot(game : GameModel, slotPos: SlotPos, card: CardT) {
+export function canAttachToSlot(game : GameModel, slotPos: SlotPos, card: CardT) {
 	const opponentPlayerId = game.getPlayerIds().find((id) => id !== slotPos.player.id)
 	if (!opponentPlayerId) return 'INVALID'
 
@@ -218,7 +218,7 @@ export function swapSlots(
 		if (!card) continue
 
 		// Make sure this card can be placed in the other slot
-		if (!canAttachAtSlot(game, otherSlot, card)) return false
+		if (!canAttachToSlot(game, otherSlot, card)) return false
 
 		const cardPos = getCardPos(game, card.cardInstance)
 		if (!cardPos) continue

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -28,7 +28,11 @@ function discardAtPos(pos: CardPosModel) {
 	}
 }
 
-export function discardCard(game: GameModel, card: CardT | null, player?: PlayerState | null) {
+export function discardCard(
+	game: GameModel,
+	card: CardT | null,
+	playerDiscard?: PlayerState | null
+) {
 	if (!card) return
 
 	const pos = getCardPos(game, card.cardInstance)
@@ -53,8 +57,8 @@ export function discardCard(game: GameModel, card: CardT | null, player?: Player
 	// Remove the card
 	discardAtPos(pos)
 
-	if (player !== null) {
-		const discardPlayer = player ? player : pos.player
+	if (playerDiscard !== null) {
+		const discardPlayer = playerDiscard ? playerDiscard : pos.player
 
 		discardPlayer.discarded.push({
 			cardId: card.cardId,
@@ -119,7 +123,7 @@ export function drawCards(playerState: PlayerState, amount: number) {
 	}
 }
 
-export function moveCardToHand(game: GameModel, card: CardT, player?: PlayerState | null) {
+export function moveCardToHand(game: GameModel, card: CardT, playerDiscard?: PlayerState | null) {
 	const cardPos = getCardPos(game, card.cardInstance)
 	if (!cardPos) return
 
@@ -138,8 +142,8 @@ export function moveCardToHand(game: GameModel, card: CardT, player?: PlayerStat
 		cardPos.player.board.singleUseCard = null
 	}
 
-	if (player !== null) {
-		const chosenPlayer = player ? player : cardPos.player
+	if (playerDiscard !== null) {
+		const chosenPlayer = playerDiscard ? playerDiscard : cardPos.player
 		chosenPlayer.hand.push(card)
 	}
 }
@@ -173,7 +177,7 @@ export function getSlotCard(slotPos: SlotPos): CardT | null {
 	return row.itemCards[index]
 }
 
-export function canAttachToSlot(game : GameModel, slotPos: SlotPos, card: CardT) {
+export function canAttachToSlot(game: GameModel, slotPos: SlotPos, card: CardT) {
 	const opponentPlayerId = game.getPlayerIds().find((id) => id !== slotPos.player.id)
 	if (!opponentPlayerId) return 'INVALID'
 

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -27,7 +27,7 @@ function discardAtPos(pos: CardPosModel) {
 	}
 }
 
-export function discardCard(game: GameModel, card: CardT | null, steal = false) {
+export function discardCard(game: GameModel, card: CardT | null, player?: PlayerState | null) {
 	if (!card) return
 
 	const pos = getCardPos(game, card.cardInstance)
@@ -59,12 +59,14 @@ export function discardCard(game: GameModel, card: CardT | null, steal = false) 
 	// Remove the card
 	discardAtPos(pos)
 
-	const discardPlayer = steal ? pos.opponentPlayer : pos.player
-
-	discardPlayer.discarded.push({
-		cardId: card.cardId,
-		cardInstance: card.cardInstance,
-	})
+	if (player !== null) {
+		const discardPlayer = player ? player : pos.player
+	
+		discardPlayer.discarded.push({
+			cardId: card.cardId,
+			cardInstance: card.cardInstance,
+		})
+	}
 }
 
 export function retrieveCard(game: GameModel, card: CardT | null) {
@@ -123,7 +125,7 @@ export function drawCards(playerState: PlayerState, amount: number) {
 	}
 }
 
-export function moveCardToHand(game: GameModel, card: CardT, steal = false) {
+export function moveCardToHand(game: GameModel, card: CardT, player?: PlayerState | null) {
 	const cardPos = getCardPos(game, card.cardInstance)
 	if (!cardPos) return
 
@@ -142,8 +144,10 @@ export function moveCardToHand(game: GameModel, card: CardT, steal = false) {
 		cardPos.player.board.singleUseCard = null
 	}
 
-	const player = steal ? cardPos.opponentPlayer : cardPos.player
-	player.hand.push(card)
+	if (player !== null) {
+		const chosenPlayer = player ? player : cardPos.player
+		chosenPlayer.hand.push(card)
+	}
 }
 
 /**Returns whether the slot is empty or not. */
@@ -175,7 +179,7 @@ export function getSlotCard(slotPos: SlotPos): CardT | null {
 	return row.itemCards[index]
 }
 
-/**Swaps the positions of two slots on the board. */
+/**Swaps the positions of two cards on the board. */
 export function swapSlots(
 	game: GameModel,
 	slotAPos: SlotPos,

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -222,7 +222,7 @@ export function swapSlots(
 		if (!card) continue
 
 		// Make sure this card can be placed in the other slot
-		if (!canAttachToSlot(game, otherSlot, card)) return false
+		if (canAttachToSlot(game, otherSlot, card) !== 'YES') return false
 
 		const cardPos = getCardPos(game, card.cardInstance)
 		if (!cardPos) continue

--- a/server/src/api.ts
+++ b/server/src/api.ts
@@ -7,6 +7,13 @@ const require = createRequire(import.meta.url)
 
 export function registerApis(app: import('express').Express) {
 	let apiKeys: any = null
+
+	const env = process.env.NODE_ENV || 'development'
+	if (env == 'development') {
+		console.log('running in dev mode, not activating api')
+		return
+	}
+
 	try {
 		apiKeys = require('./apiKeys.json')
 


### PR DESCRIPTION
HC-TCG Online Update v0.6.41 Changelog:
- Updated wolf card - new description is as follows: `If any of your Hermits are attacked on your opponent's turn, your opponent's active hermit takes 20hp damage. Must be placed on active Hermit, but still activates while on afk.`. The token cost is still 1.
- Changed logo subtext to "Woof woof."
- Fixed health after attack being clamped to hermit's max health
- Cards can no longer be moved if they aren't supposed to be placed in a certain slot. This affects grian, emerald, mending, etc.
- Fixed target block changing attack type
- Changed weakness to only count attacks that have a multiplier of 0 as a missed attack
- Improved armor descriptions to clarify they only affect the Hermit they are attached to
- Unmet condition modal now mentions that your card might not be usable due to the slot you've chosen.