### PR TITLE
CanAttach Refactor

### DIFF
--- a/client/src/logic/game/tasks/action-logic-saga.ts
+++ b/client/src/logic/game/tasks/action-logic-saga.ts
@@ -48,7 +48,7 @@ function* actionLogicSaga(gameState: LocalGameState): SagaIterator {
 		pState.board.singleUseCard
 	) {
 		yield call(singleUseSaga, pState.board.singleUseCard)
-	} else if (lastActionResult?.result === 'FAILURE_CANNOT_ATTACH') {
+	} else if (lastActionResult?.result === 'FAILURE_UNMET_CONDITION') {
 		yield put(setOpenedModal('unmet-condition'))
 	}
 }

--- a/common/cards/advent-of-tcg/effects/berry-bush.ts
+++ b/common/cards/advent-of-tcg/effects/berry-bush.ts
@@ -86,10 +86,6 @@ class BerryBushEffectCard extends EffectCard {
 		return 'YES'
 	}
 
-	override canAttachToCard(game: GameModel, pos: CardPosModel) {
-		return false
-	}
-
 	public override getActions(game: GameModel): TurnActions {
 		const {opponentPlayer} = game
 

--- a/common/cards/advent-of-tcg/effects/berry-bush.ts
+++ b/common/cards/advent-of-tcg/effects/berry-bush.ts
@@ -5,6 +5,8 @@ import {discardCard} from '../../../utils/movement'
 import {CardPosModel, getBasicCardPos} from '../../../models/card-pos-model'
 import {TurnActions} from '../../../types/game-state'
 import {getActiveRow} from '../../../utils/board'
+import {CanAttachResult} from '../../base/card'
+import {hasActive} from '../../../utils/game'
 
 class BerryBushEffectCard extends EffectCard {
 	constructor() {
@@ -19,9 +21,7 @@ class BerryBushEffectCard extends EffectCard {
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {
-		const newPos = getBasicCardPos(game, instance)
-		if (!newPos) return
-		const {player, opponentPlayer, row, rowIndex} = newPos
+		const {player, opponentPlayer, row} = pos
 		if (!row) return
 
 		row.health = 30
@@ -31,6 +31,11 @@ class BerryBushEffectCard extends EffectCard {
 				// Discard to prevent losing a life
 				discardCard(game, row.hermitCard)
 			}
+		})
+
+		player.hooks.canAttach.add(instance, (result, pos) => {
+			if (pos.row?.hermitCard?.cardInstance !== instance) return
+			if (['item', 'effect'].includes(pos.slot.type)) result.push('UNMET_CONDITION_SILENT')
 		})
 
 		opponentPlayer.hooks.afterAttack.add(instance, () => {
@@ -70,6 +75,7 @@ class BerryBushEffectCard extends EffectCard {
 		}
 
 		player.hooks.afterAttack.remove(instance)
+		player.hooks.canAttach.remove(instance)
 		opponentPlayer.hooks.afterAttack.remove(instance)
 		opponentPlayer.hooks.onTurnEnd.remove(instance)
 	}
@@ -77,13 +83,13 @@ class BerryBushEffectCard extends EffectCard {
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const {slot} = pos
 		const {currentPlayer, opponentPlayer} = game
+		const result: CanAttachResult = []
 
-		if (!slot || slot.type !== 'hermit') return 'INVALID'
-		if (pos.player.id !== opponentPlayer.id) return 'INVALID'
-		if (opponentPlayer.board.activeRow === null) return 'INVALID'
-		if (currentPlayer.board.activeRow === null) return 'INVALID'
+		if (!slot || slot.type !== 'hermit') result.push('INVALID_SLOT')
+		if (pos.player.id !== opponentPlayer.id) result.push('INVALID_PLAYER')
+		if (!hasActive(opponentPlayer) || !hasActive(currentPlayer)) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	public override getActions(game: GameModel): TurnActions {

--- a/common/cards/advent-of-tcg/effects/brewing-stand.ts
+++ b/common/cards/advent-of-tcg/effects/brewing-stand.ts
@@ -34,7 +34,7 @@ class BrewingStandEffectCard extends EffectCard {
 				id: this.id,
 				message: 'Pick an item card to discard',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 					if (pickResult.rowIndex !== pos.rowIndex) return 'FAILURE_INVALID_SLOT'
 
 					if (pickResult.slot.type !== 'item') return 'FAILURE_INVALID_SLOT'

--- a/common/cards/advent-of-tcg/effects/slimeball.ts
+++ b/common/cards/advent-of-tcg/effects/slimeball.ts
@@ -3,7 +3,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {TurnActions} from '../../../types/game-state'
 import {discardCard, isSlotEmpty} from '../../../utils/movement'
-import {CanAttachError} from '../../base/card'
+import {CanAttachResult} from '../../base/card'
 import EffectCard from '../../base/effect-card'
 
 class SlimeballEffectCard extends EffectCard {
@@ -18,12 +18,13 @@ class SlimeballEffectCard extends EffectCard {
 		})
 	}
 
-	override canAttach(game: GameModel, pos: CardPosModel): CanAttachError {
-		if (pos.slot.type !== 'effect') return 'NO_INVALID_SLOT'
+	override canAttach(game: GameModel, pos: CardPosModel) {
+		const result: CanAttachResult = []
+		if (pos.slot.type !== 'effect') result.push('INVALID_SLOT')
 
-		if (!pos.row?.hermitCard) return 'NO_UNMET_CONDITION_SILENT'
+		if (!pos.row?.hermitCard) result.push('UNMET_CONDITION_SILENT')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/advent-of-tcg/effects/slimeball.ts
+++ b/common/cards/advent-of-tcg/effects/slimeball.ts
@@ -3,6 +3,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {TurnActions} from '../../../types/game-state'
 import {discardCard, isSlotEmpty} from '../../../utils/movement'
+import {CanAttachError} from '../../base/card'
 import EffectCard from '../../base/effect-card'
 
 class SlimeballEffectCard extends EffectCard {
@@ -17,14 +18,10 @@ class SlimeballEffectCard extends EffectCard {
 		})
 	}
 
-	override canAttach(game: GameModel, pos: CardPosModel) {
-		if (pos.slot.type !== 'effect') return 'INVALID'
+	override canAttach(game: GameModel, pos: CardPosModel): CanAttachError {
+		if (pos.slot.type !== 'effect') return 'NO_INVALID_SLOT'
 
-		if (!pos.row?.hermitCard) return 'INVALID'
-
-		const cardInfo = CARDS[pos.row.hermitCard.cardId]
-		if (!cardInfo) return 'INVALID'
-		if (!cardInfo.canAttachToCard(game, pos)) return 'NO'
+		if (!pos.row?.hermitCard) return 'NO_UNMET_CONDITION_SILENT'
 
 		return 'YES'
 	}

--- a/common/cards/advent-of-tcg/hermits/dungeontango-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/dungeontango-rare.ts
@@ -50,7 +50,7 @@ class DungeonTangoRareHermitCard extends HermitCard {
 				id: this.id,
 				message: 'Choose an item card to discard',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex !== player.board.activeRow) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/advent-of-tcg/hermits/ldshadowlady-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/ldshadowlady-rare.ts
@@ -54,7 +54,7 @@ class LDShadowLadyRareHermitCard extends HermitCard {
 				message: "Move your opponent's active Hermit to a new slot.",
 				onResult(pickResult) {
 					// Validation
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 					if (pickResult.rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
 					if (pickResult.slot.type !== 'hermit') return 'FAILURE_INVALID_SLOT'
 					if (pickResult.card !== null) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
@@ -53,7 +53,7 @@ class MonkeyfarmRareHermitCard extends HermitCard {
 				id: this.id,
 				message: "Pick one of your opponent's AFK Hermit's item cards",
 				onResult(pickResult) {
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/advent-of-tcg/hermits/orionsound-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/orionsound-rare.ts
@@ -41,7 +41,7 @@ class OrionSoundRareHermitCard extends HermitCard {
 				id: instance,
 				message: 'Choose an Active or AFK Hermit to heal.',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/advent-of-tcg/hermits/smajor1995.ts
+++ b/common/cards/advent-of-tcg/hermits/smajor1995.ts
@@ -46,7 +46,7 @@ class Smajor1995RareHermitCard extends HermitCard {
 				id: instance,
 				message: 'Choose an AFK Hermit to dye.',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined || rowIndex === player.board.activeRow)

--- a/common/cards/advent-of-tcg/hermits/solidaritygaming-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/solidaritygaming-rare.ts
@@ -60,7 +60,7 @@ class SolidaritygamingRareHermitCard extends HermitCard {
 				id: instance,
 				message: 'Choose an AFK Hermit to protect',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined || rowIndex === player.board.activeRow)

--- a/common/cards/advent-of-tcg/single-use/brush.ts
+++ b/common/cards/advent-of-tcg/single-use/brush.ts
@@ -62,14 +62,13 @@ class BrushSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 		const {player} = pos
 
 		// Cannot use if you have 3 or less cards
-		if (player.pile.length <= 3) return 'NO'
+		if (player.pile.length <= 3) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/advent-of-tcg/single-use/fletching-table.ts
+++ b/common/cards/advent-of-tcg/single-use/fletching-table.ts
@@ -1,5 +1,6 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
+import {CanAttachResult} from '../../base/card'
 import SingleUseCard from '../../base/single-use-card'
 
 class FletchingTableSingleUseCard extends SingleUseCard {
@@ -13,8 +14,8 @@ class FletchingTableSingleUseCard extends SingleUseCard {
 		})
 	}
 
-	public override canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID' {
-		return 'NO'
+	public override canAttach(game: GameModel, pos: CardPosModel): CanAttachResult {
+		return ['INVALID_SLOT']
 	}
 
 	public override getExpansion(): string {

--- a/common/cards/advent-of-tcg/single-use/lantern.ts
+++ b/common/cards/advent-of-tcg/single-use/lantern.ts
@@ -15,14 +15,13 @@ class LanternSingleUseCard extends SingleUseCard {
 		})
 	}
 
-	override canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID' {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+	override canAttach(game: GameModel, pos: CardPosModel) {
+		const result = super.canAttach(game, pos)
 
 		const {player} = pos
-		if (player.pile.length < 4) return 'NO'
+		if (player.pile.length < 4) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override canApply() {

--- a/common/cards/alter-egos/effects/armor-stand.ts
+++ b/common/cards/alter-egos/effects/armor-stand.ts
@@ -4,6 +4,7 @@ import {GameModel} from '../../../models/game-model'
 import {discardCard} from '../../../utils/movement'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {TurnActions} from '../../../types/game-state'
+import {CanAttachResult} from '../../base/card'
 
 class ArmorStandEffectCard extends EffectCard {
 	constructor() {
@@ -52,6 +53,11 @@ class ArmorStandEffectCard extends EffectCard {
 			}
 		})
 
+		player.hooks.canAttach.add(instance, (result, pos) => {
+			if (pos.row?.hermitCard?.cardInstance !== instance) return
+			if (['item', 'effect'].includes(pos.slot.type)) result.push('UNMET_CONDITION_SILENT')
+		})
+
 		opponentPlayer.hooks.afterAttack.add(instance, (attack) => {
 			const attacker = attack.getAttacker()
 			if (!row.health && attacker && isTargetingPos(attack, pos)) {
@@ -78,6 +84,7 @@ class ArmorStandEffectCard extends EffectCard {
 
 		player.hooks.blockedActions.remove(instance)
 		player.hooks.afterAttack.remove(instance)
+		player.hooks.canAttach.remove(instance)
 		opponentPlayer.hooks.afterAttack.remove(instance)
 		delete player.custom[this.getInstanceKey(instance)]
 	}
@@ -85,15 +92,12 @@ class ArmorStandEffectCard extends EffectCard {
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const {slot} = pos
 		const {currentPlayer} = game
+		const result: CanAttachResult = []
 
-		if (!slot || slot.type !== 'hermit') return 'INVALID'
-		if (pos.player.id !== currentPlayer.id) return 'INVALID'
+		if (!slot || slot.type !== 'hermit') result.push('INVALID_SLOT')
+		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
 
-		return 'YES'
-	}
-
-	override canAttachToCard(game: GameModel, pos: CardPosModel) {
-		return false
+		return result
 	}
 
 	public override getActions(game: GameModel): TurnActions {

--- a/common/cards/alter-egos/effects/armor-stand.ts
+++ b/common/cards/alter-egos/effects/armor-stand.ts
@@ -55,7 +55,7 @@ class ArmorStandEffectCard extends EffectCard {
 
 		player.hooks.canAttach.add(instance, (result, pos) => {
 			if (pos.row?.hermitCard?.cardInstance !== instance) return
-			if (['item', 'effect'].includes(pos.slot.type)) result.push('UNMET_CONDITION_SILENT')
+			result.push('UNMET_CONDITION_SILENT')
 		})
 
 		opponentPlayer.hooks.afterAttack.add(instance, (attack) => {

--- a/common/cards/alter-egos/effects/lightning-rod.ts
+++ b/common/cards/alter-egos/effects/lightning-rod.ts
@@ -17,16 +17,15 @@ class LightningRodEffectCard extends EffectCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const board = pos.player.board
 		if (board.rows.find((row) => row.effectCard?.cardId === this.id)) {
 			// Can't attach if there's already one attached
-			return 'NO'
+			result.push('UNMET_CONDITION')
 		}
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/alter-egos/effects/string.ts
+++ b/common/cards/alter-egos/effects/string.ts
@@ -2,6 +2,7 @@ import {CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {TurnActions} from '../../../types/game-state'
+import {CanAttachResult} from '../../base/card'
 import EffectCard from '../../base/effect-card'
 
 class StringEffectCard extends EffectCard {
@@ -19,15 +20,17 @@ class StringEffectCard extends EffectCard {
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const {opponentPlayer} = game
 
+		const result: CanAttachResult = []
+
 		// attach to effect or item slot
-		if (pos.slot.type !== 'effect' && pos.slot.type !== 'item') return 'INVALID'
+		if (pos.slot.type !== 'effect' && pos.slot.type !== 'item') result.push('INVALID_SLOT')
 
 		// can only attach to opponent
-		if (pos.player.id !== opponentPlayer.id) return 'INVALID'
+		if (pos.player.id !== opponentPlayer.id) result.push('INVALID_PLAYER')
 
-		if (!pos.row?.hermitCard) return 'INVALID'
+		if (!pos.row?.hermitCard) result.push('UNMET_CONDITION_SILENT')
 
-		return 'YES'
+		return []
 	}
 
 	// This card allows placing on either effect or item slot

--- a/common/cards/alter-egos/effects/string.ts
+++ b/common/cards/alter-egos/effects/string.ts
@@ -27,10 +27,6 @@ class StringEffectCard extends EffectCard {
 
 		if (!pos.row?.hermitCard) return 'INVALID'
 
-		const cardInfo = CARDS[pos.row.hermitCard.cardId]
-		if (!cardInfo) return 'INVALID'
-		if (!cardInfo.canAttachToCard(game, pos)) return 'NO'
-
 		return 'YES'
 	}
 

--- a/common/cards/alter-egos/effects/turtle-shell.ts
+++ b/common/cards/alter-egos/effects/turtle-shell.ts
@@ -17,15 +17,14 @@ class TurtleShellEffectCard extends EffectCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const {currentPlayer} = game
+		const {player} = pos
 
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		// turtle shell addition - hermit must be inactive to attach
-		if (!(currentPlayer.board.activeRow !== pos.rowIndex)) return 'NO'
+		if (!(player.board.activeRow !== pos.rowIndex)) result.push('INVALID_SLOT')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/alter-egos/hermits/humancleo-rare.ts
+++ b/common/cards/alter-egos/hermits/humancleo-rare.ts
@@ -95,7 +95,7 @@ class HumanCleoRareHermitCard extends HermitCard {
 					id: this.id,
 					message: 'Pick one of your AFK Hermits',
 					onResult(pickResult) {
-						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 						const rowIndex = pickResult.rowIndex
 						if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/alter-egos/hermits/jingler-rare.ts
+++ b/common/cards/alter-egos/hermits/jingler-rare.ts
@@ -46,7 +46,7 @@ class JinglerRareHermitCard extends HermitCard {
 				message: 'Pick 1 card from your hand to discard',
 				onResult(pickResult) {
 					// Validation
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 					if (pickResult.slot.type !== 'hand') return 'FAILURE_INVALID_SLOT'
 
 					discardFromHand(opponentPlayer, pickResult.card)

--- a/common/cards/alter-egos/single-use/anvil.ts
+++ b/common/cards/alter-egos/single-use/anvil.ts
@@ -2,6 +2,7 @@ import {AttackModel} from '../../../models/attack-model'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {applySingleUse, getActiveRowPos} from '../../../utils/board'
+import {hasActive} from '../../../utils/game'
 import SingleUseCard from '../../base/single-use-card'
 
 class AnvilSingleUseCard extends SingleUseCard {
@@ -76,14 +77,12 @@ class AnvilSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const {player} = pos
-		const activeRow = player.board.activeRow
-		if (activeRow === null) return 'NO'
+		if (!hasActive(player)) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override getExpansion() {

--- a/common/cards/alter-egos/single-use/bad-omen.ts
+++ b/common/cards/alter-egos/single-use/bad-omen.ts
@@ -2,6 +2,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import SingleUseCard from '../../base/single-use-card'
 import {applyStatusEffect} from '../../../utils/board'
+import {hasActive} from '../../../utils/game'
 
 class BadOmenSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -40,13 +41,11 @@ class BadOmenSingleUseCard extends SingleUseCard {
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const {opponentPlayer} = pos
 
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
-		const activeRow = opponentPlayer.board.activeRow
-		if (activeRow === null) return 'NO'
+		if (!hasActive(opponentPlayer)) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override getExpansion() {

--- a/common/cards/alter-egos/single-use/egg.ts
+++ b/common/cards/alter-egos/single-use/egg.ts
@@ -19,15 +19,14 @@ class EggSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const {opponentPlayer} = pos
 
 		const inactiveHermits = getNonEmptyRows(opponentPlayer, true)
-		if (inactiveHermits.length === 0) return 'NO'
+		if (inactiveHermits.length === 0) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/alter-egos/single-use/egg.ts
+++ b/common/cards/alter-egos/single-use/egg.ts
@@ -40,7 +40,7 @@ class EggSingleUseCard extends SingleUseCard {
 				id: this.id,
 				message: "Pick one of your opponent's AFK Hermits",
 				onResult(pickResult) {
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/alter-egos/single-use/ender-pearl.ts
+++ b/common/cards/alter-egos/single-use/ender-pearl.ts
@@ -3,6 +3,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {executeAttacks} from '../../../utils/attacks'
 import {applySingleUse, getActiveRowPos} from '../../../utils/board'
+import {hasActive} from '../../../utils/game'
 import SingleUseCard from '../../base/single-use-card'
 
 class EnderPearlSingleUseCard extends SingleUseCard {
@@ -18,15 +19,15 @@ class EnderPearlSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const {player} = pos
-		if (player.board.activeRow === undefined) return 'NO'
+		if (!hasActive(player)) result.push('UNMET_CONDITION')
 		for (const row of player.board.rows) {
-			if (row.hermitCard === null) return 'YES'
+			if (row.hermitCard === null) return result
 		}
-		return 'NO'
+		result.push('UNMET_CONDITION')
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/alter-egos/single-use/ender-pearl.ts
+++ b/common/cards/alter-egos/single-use/ender-pearl.ts
@@ -38,7 +38,7 @@ class EnderPearlSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick an empty Hermit slot',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/alter-egos/single-use/fire-charge.ts
+++ b/common/cards/alter-egos/single-use/fire-charge.ts
@@ -50,7 +50,7 @@ class FireChargeSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick an item or effect card from one of your active or AFK Hermits',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 				if (pickResult.rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
 				if (pickResult.slot.type !== 'item' && pickResult.slot.type !== 'effect')
 					return 'FAILURE_INVALID_SLOT'

--- a/common/cards/alter-egos/single-use/fire-charge.ts
+++ b/common/cards/alter-egos/single-use/fire-charge.ts
@@ -18,9 +18,8 @@ class FireChargeSingleUseCard extends SingleUseCard {
 		})
 	}
 
-	override canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID' {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+	override canAttach(game: GameModel, pos: CardPosModel) {
+		const result = super.canAttach(game, pos)
 
 		const {player} = pos
 
@@ -36,10 +35,11 @@ class FireChargeSingleUseCard extends SingleUseCard {
 				}
 			}
 
-			if ((row.effectCard !== null && isRemovable(row.effectCard)) || total > 0) return 'YES'
+			if ((row.effectCard !== null && isRemovable(row.effectCard)) || total > 0) return result
 		}
 
-		return 'NO'
+		result.push('UNMET_CONDITION')
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/alter-egos/single-use/ladder.ts
+++ b/common/cards/alter-egos/single-use/ladder.ts
@@ -36,7 +36,7 @@ class LadderSingleUseCard extends SingleUseCard {
 					if (!row.hermitCard) continue
 
 					const hermitSlot = getSlotPos(pos.player, index, 'hermit')
-					if (canAttachToSlot(game, hermitSlot, activeRow.hermitCard).length > 0) continue
+					if (canAttachToSlot(game, hermitSlot, activeRow.hermitCard, true).length > 0) continue
 
 					// We found somewhere to attach
 					return result
@@ -78,7 +78,7 @@ class LadderSingleUseCard extends SingleUseCard {
 				const inactivePos = getSlotPos(player, pickedIndex, 'hermit')
 				const card = getSlotCard(activePos)
 
-				if (canAttachToSlot(game, inactivePos, card!).length > 0) {
+				if (canAttachToSlot(game, inactivePos, card!, true).length > 0) {
 					return 'FAILURE_INVALID_SLOT'
 				}
 

--- a/common/cards/alter-egos/single-use/ladder.ts
+++ b/common/cards/alter-egos/single-use/ladder.ts
@@ -5,6 +5,7 @@ import {isCardType} from '../../../utils/cards'
 import {canAttachToSlot, swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
 
+// @NOWTODO
 class LadderSingleUseCard extends SingleUseCard {
 	constructor() {
 		super({
@@ -51,7 +52,7 @@ class LadderSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick an AFK Hermit adjacent to your active Hermit',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				if (pickResult.slot.type !== 'hermit') return 'FAILURE_INVALID_SLOT'
 				if (!pickResult.card) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/alter-egos/single-use/piston.ts
+++ b/common/cards/alter-egos/single-use/piston.ts
@@ -47,7 +47,7 @@ class PistonSingleUseCard extends SingleUseCard {
 					for (let i = 0; i < 3; i++) {
 						const targetSlot = getSlotPos(player, index, 'item', i)
 
-						if (canAttachToSlot(game, targetSlot, item).length > 0) continue
+						if (canAttachToSlot(game, targetSlot, item, true).length > 0) continue
 
 						// We're good to place
 						return result
@@ -116,7 +116,7 @@ class PistonSingleUseCard extends SingleUseCard {
 				const itemPos = getSlotPos(player, firstRowIndex, 'item', itemIndex)
 				const targetPos = getSlotPos(player, pickedIndex, 'item', pickResult.slot.index)
 				const itemCard = firstRow.itemCards[itemIndex]
-				if (canAttachToSlot(game, targetPos, itemCard!).length > 0) {
+				if (canAttachToSlot(game, targetPos, itemCard!, true).length > 0) {
 					return 'FAILURE_INVALID_SLOT'
 				}
 

--- a/common/cards/alter-egos/single-use/piston.ts
+++ b/common/cards/alter-egos/single-use/piston.ts
@@ -1,17 +1,12 @@
 import {CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {
-	applySingleUse,
-	canAttachToCard,
-	getSlotPos,
-	isRowEmpty,
-	rowHasEmptyItemSlot,
-} from '../../../utils/board'
+import {applySingleUse, getSlotPos, isRowEmpty, rowHasEmptyItemSlot} from '../../../utils/board'
 import {isCardType} from '../../../utils/cards'
 import {discardSingleUse, swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
 
+// @NOWTODO
 class PistonSingleUseCard extends SingleUseCard {
 	constructor() {
 		super({
@@ -60,7 +55,7 @@ class PistonSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick an item card from one of your active or AFK Hermits',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
@@ -80,7 +75,7 @@ class PistonSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick an empty item slot on one of your adjacent active or AFK Hermits',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				const pickedIndex = pickResult.rowIndex
 				if (pickedIndex === undefined) return 'FAILURE_INVALID_SLOT'
@@ -105,7 +100,7 @@ class PistonSingleUseCard extends SingleUseCard {
 
 				// Make sure we can attach the item
 				const itemCard = firstRow.itemCards[itemIndex]
-				if (!canAttachToCard(game, pickedRow.hermitCard, itemCard)) return 'FAILURE_INVALID_SLOT'
+				// @NOWTODO call canAttachToSlot
 
 				// Move the item
 				const itemPos = getSlotPos(player, firstRowIndex, 'item', itemIndex)

--- a/common/cards/alter-egos/single-use/potion-of-weakness.ts
+++ b/common/cards/alter-egos/single-use/potion-of-weakness.ts
@@ -1,8 +1,10 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {getActiveRow} from '../../../utils/board'
+import {CanAttachResult} from '../../base/card'
 import SingleUseCard from '../../base/single-use-card'
 import {applyStatusEffect} from '../../../utils/board'
+import {hasActive} from '../../../utils/game'
 
 class PotionOfWeaknessSingleUseCard extends SingleUseCard {
 	constructor() {
@@ -21,11 +23,12 @@ class PotionOfWeaknessSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		if (pos.slot.type !== 'single_use') return 'INVALID'
+		const result: CanAttachResult = []
+		if (pos.slot.type !== 'single_use') result.push('INVALID_SLOT')
 
-		if (pos.opponentPlayer.board.activeRow === null) return 'NO'
+		if (!hasActive(pos.opponentPlayer)) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/alter-egos/single-use/sweeping-edge.ts
+++ b/common/cards/alter-egos/single-use/sweeping-edge.ts
@@ -17,12 +17,14 @@ class SweepingEdgeSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const {opponentPlayer} = pos
 		const activeRow = opponentPlayer.board.activeRow
-		if (activeRow === null) return 'NO'
+		if (activeRow === null) {
+			result.push('UNMET_CONDITION')
+			return result
+		}
 
 		const rows = opponentPlayer.board.rows
 		const targetIndex = [activeRow - 1, activeRow, activeRow + 1].filter(
@@ -31,10 +33,11 @@ class SweepingEdgeSingleUseCard extends SingleUseCard {
 
 		for (const row of targetIndex) {
 			const effectCard = rows[row].effectCard
-			if (effectCard && isRemovable(effectCard)) return 'YES'
+			if (effectCard && isRemovable(effectCard)) return result
 		}
 
-		return 'NO'
+		result.push('UNMET_CONDITION')
+		return result
 	}
 
 	override canApply() {

--- a/common/cards/alter-egos/single-use/target-block.ts
+++ b/common/cards/alter-egos/single-use/target-block.ts
@@ -36,7 +36,7 @@ class TargetBlockSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: "Pick one of your opponent's AFK Hermits",
 			onResult(pickResult) {
-				if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/alter-egos/single-use/target-block.ts
+++ b/common/cards/alter-egos/single-use/target-block.ts
@@ -17,14 +17,13 @@ class TargetBlockSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 		const {opponentPlayer} = pos
 
 		// Inactive Hermits
-		if (getNonEmptyRows(opponentPlayer, true).length === 0) return 'NO'
+		if (getNonEmptyRows(opponentPlayer, true).length === 0) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/base/card.ts
+++ b/common/cards/base/card.ts
@@ -2,12 +2,15 @@ import {CardRarityT, CardTypeT} from '../../types/cards'
 import {GameModel} from '../../models/game-model'
 import {CardPosModel} from '../../models/card-pos-model'
 import {TurnActions} from '../../types/game-state'
-import {HermitAttackType} from '../../types/attack'
-import {PickRequest} from '../../types/server-requests'
 
-export type CanAttachResult = Array<
-	'INVALID_PLAYER' | 'INVALID_SLOT' | 'UNMET_CONDITION' | 'UNMET_CONDITION_SILENT' | 'UNKNOWN_ERROR'
->
+export type CanAttachError =
+	| 'INVALID_PLAYER'
+	| 'INVALID_SLOT'
+	| 'UNMET_CONDITION'
+	| 'UNMET_CONDITION_SILENT'
+	| 'UNKNOWN_ERROR'
+
+export type CanAttachResult = Array<CanAttachError>
 
 type CardDefs = {
 	type: CardTypeT

--- a/common/cards/base/card.ts
+++ b/common/cards/base/card.ts
@@ -5,6 +5,10 @@ import {TurnActions} from '../../types/game-state'
 import {HermitAttackType} from '../../types/attack'
 import {PickRequest} from '../../types/server-requests'
 
+export type CanAttachResult = Array<
+	'INVALID_PLAYER' | 'INVALID_SLOT' | 'UNMET_CONDITION' | 'UNMET_CONDITION_SILENT' | 'UNKNOWN_ERROR'
+>
+
 type CardDefs = {
 	type: CardTypeT
 	id: string
@@ -37,22 +41,10 @@ abstract class Card {
 
 	/**
 	 * If the specified slot is empty, can this card be attached there
-	 * 
-	 * YES - Card can be attached to the slot
-	 * 
-	 * NO - This card normally can be attached in the slot but something is preventing it (Shows a popup)
-	 * 
-	 * INVALID - This card can never be attached in the slot - it's an invalid slot
+	 *
+	 * Returns an array of any of the problems there are with attaching, if any
 	 */
-	public abstract canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID'
-
-	/**
-	 * If this card is attached to a Hermit slot, can another card be attached to the row this card is in
-	 */
-	public canAttachToCard(game: GameModel, pos: CardPosModel): boolean {
-		// default is true
-		return true
-	}
+	public abstract canAttach(game: GameModel, pos: CardPosModel): CanAttachResult
 
 	/**
 	 * Called when an instance of this card is attached to the board

--- a/common/cards/base/effect-card.ts
+++ b/common/cards/base/effect-card.ts
@@ -1,4 +1,4 @@
-import Card from './card'
+import Card, {CanAttachResult} from './card'
 import {CARDS} from '..'
 import {GameModel} from '../../models/game-model'
 import {CardRarityT} from '../../types/cards'
@@ -28,21 +28,18 @@ abstract class EffectCard extends Card {
 		this.description = defs.description
 	}
 
-	public override canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID' {
+	public override canAttach(game: GameModel, pos: CardPosModel): CanAttachResult {
 		const {currentPlayer} = game
 
-		// Wrong slot
-		if (pos.slot.type !== 'effect') return 'INVALID'
-		if (pos.player.id !== currentPlayer.id) return 'INVALID'
+		const result: CanAttachResult = []
 
-		// Can't attach without hermit card - this is considered like the wrong slot
-		if (!pos.row?.hermitCard) return 'INVALID'
+		if (pos.slot.type !== 'effect') result.push('INVALID_SLOT')
+		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
 
-		const cardInfo = CARDS[pos.row.hermitCard?.cardId]
-		if (!cardInfo) return 'INVALID'
-		if (!cardInfo.canAttachToCard(game, pos)) return 'NO'
+		// Can't attach without hermit card - this is not going to show the unmet condition modal
+		if (!pos.row?.hermitCard) result.push('UNMET_CONDITION_SILENT')
 
-		return 'YES'
+		return result
 	}
 
 	public override getActions(game: GameModel): TurnActions {

--- a/common/cards/base/effect-card.ts
+++ b/common/cards/base/effect-card.ts
@@ -57,6 +57,8 @@ abstract class EffectCard extends Card {
 		return true
 	}
 
+	// @TODO replace with canDetach hook, need a standardized way to attach and detach things
+	// All cards that check for canAttach now eventually need to check canDetach too.
 	/**
 	 * Returns whether this card is removable from its position
 	 */

--- a/common/cards/base/health-card.ts
+++ b/common/cards/base/health-card.ts
@@ -26,8 +26,8 @@ class HealthCard extends Card {
 		this.health = defs.health
 	}
 
-	public override canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID' {
-		return 'YES'
+	public override canAttach(game: GameModel, pos: CardPosModel) {
+		return []
 	}
 }
 

--- a/common/cards/base/hermit-card.ts
+++ b/common/cards/base/hermit-card.ts
@@ -1,6 +1,6 @@
 import {AttackModel} from '../../models/attack-model'
 import {GameModel} from '../../models/game-model'
-import Card from './card'
+import Card, {CanAttachResult} from './card'
 import {CardRarityT, HermitAttackInfo, HermitTypeT} from '../../types/cards'
 import {HermitAttackType} from '../../types/attack'
 import {CardPosModel} from '../../models/card-pos-model'
@@ -38,13 +38,15 @@ abstract class HermitCard extends Card {
 		this.secondary = defs.secondary
 	}
 
-	public override canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID' {
+	public override canAttach(game: GameModel, pos: CardPosModel): CanAttachResult {
 		const {currentPlayer} = game
 
-		if (pos.slot.type !== 'hermit') return 'INVALID'
-		if (pos.player.id !== currentPlayer.id) return 'INVALID'
+		const result: CanAttachResult = []
 
-		return 'YES'
+		if (pos.slot.type !== 'hermit') result.push('INVALID_SLOT')
+		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
+
+		return result
 	}
 
 	// Default is to return

--- a/common/cards/base/item-card.ts
+++ b/common/cards/base/item-card.ts
@@ -1,4 +1,4 @@
-import Card from './card'
+import Card, {CanAttachResult} from './card'
 import {CARDS} from '..'
 import {CardRarityT, EnergyT, HermitTypeT} from '../../types/cards'
 import {GameModel} from '../../models/game-model'
@@ -28,20 +28,18 @@ abstract class ItemCard extends Card {
 		this.hermitType = defs.hermitType
 	}
 
-	public override canAttach(game: GameModel, pos: CardPosModel) {
+	public override canAttach(game: GameModel, pos: CardPosModel): CanAttachResult {
 		const {currentPlayer} = game
 
-		if (pos.slot.type !== 'item') return 'INVALID'
-		if (pos.player.id !== currentPlayer.id) return 'INVALID'
+		const result: CanAttachResult = []
 
-		// Can't attach without hermit - this is treated like invalid slot
-		if (!pos.row?.hermitCard) return 'INVALID'
+		if (pos.slot.type !== 'item') result.push('INVALID_SLOT')
+		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
 
-		const cardInfo = CARDS[pos.row.hermitCard?.cardId]
-		if (!cardInfo) return 'INVALID'
-		if (!cardInfo.canAttachToCard(game, pos)) return 'NO'
+		// Can't attach without hermit - this does not show the unment condition modal
+		if (!pos.row?.hermitCard) result.push('UNMET_CONDITION_SILENT')
 
-		return 'YES'
+		return result
 	}
 
 	public override getActions(game: GameModel): TurnActions {

--- a/common/cards/base/single-use-card.ts
+++ b/common/cards/base/single-use-card.ts
@@ -1,5 +1,5 @@
 import {CardRarityT} from '../../types/cards'
-import Card from './card'
+import Card, {CanAttachResult} from './card'
 import {GameModel} from '../../models/game-model'
 import {CardPosModel} from '../../models/card-pos-model'
 import {TurnActions} from '../../types/game-state'
@@ -27,10 +27,10 @@ class SingleUseCard extends Card {
 		this.description = defs.description
 	}
 
-	public override canAttach(game: GameModel, pos: CardPosModel): 'YES' | 'NO' | 'INVALID' {
-		if (pos.slot.type !== 'single_use') return 'INVALID'
+	public override canAttach(game: GameModel, pos: CardPosModel): CanAttachResult {
+		if (pos.slot.type !== 'single_use') return ['INVALID_SLOT']
 
-		return 'YES'
+		return []
 	}
 
 	public override getActions(game: GameModel): TurnActions {

--- a/common/cards/default/effects/bed.ts
+++ b/common/cards/default/effects/bed.ts
@@ -18,10 +18,10 @@ class BedEffectCard extends EffectCard {
 	}
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const result = super.canAttach(game, pos)
-		const {currentPlayer} = game
+		const {player} = pos
 
 		// bed addition - hermit must also be active to attach
-		if (!(currentPlayer.board.activeRow === pos.rowIndex)) result.push('UNMET_CONDITION')
+		if (!(player.board.activeRow === pos.rowIndex)) result.push('UNMET_CONDITION')
 
 		return result
 	}

--- a/common/cards/default/effects/bed.ts
+++ b/common/cards/default/effects/bed.ts
@@ -17,15 +17,13 @@ class BedEffectCard extends EffectCard {
 		})
 	}
 	override canAttach(game: GameModel, pos: CardPosModel) {
+		const result = super.canAttach(game, pos)
 		const {currentPlayer} = game
 
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
 		// bed addition - hermit must also be active to attach
-		if (!(currentPlayer.board.activeRow === pos.rowIndex)) return 'NO'
+		if (!(currentPlayer.board.activeRow === pos.rowIndex)) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/effects/milk-bucket.ts
+++ b/common/cards/default/effects/milk-bucket.ts
@@ -102,7 +102,7 @@ class MilkBucketEffectCard extends EffectCard {
 		if (!['single_use', 'effect'].includes(pos.slot.type)) result.push('INVALID_SLOT')
 		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
 		if (pos.slot.type === 'effect') {
-			if (!pos.row?.hermitCard) result.push('INVALID_SLOT')
+			if (!pos.row?.hermitCard) result.push('UNMET_CONDITION_SILENT')
 		}
 
 		return result

--- a/common/cards/default/effects/milk-bucket.ts
+++ b/common/cards/default/effects/milk-bucket.ts
@@ -4,6 +4,7 @@ import {TurnActions} from '../../../types/game-state'
 import EffectCard from '../../base/effect-card'
 import {CARDS} from '../..'
 import {applySingleUse, removeStatusEffect} from '../../../utils/board'
+import {CanAttachResult} from '../../base/card'
 
 class MilkBucketEffectCard extends EffectCard {
 	constructor() {
@@ -96,14 +97,15 @@ class MilkBucketEffectCard extends EffectCard {
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const {currentPlayer} = game
+		const result: CanAttachResult = []
 
-		if (!['single_use', 'effect'].includes(pos.slot.type)) return 'INVALID'
-		if (pos.player.id !== currentPlayer.id) return 'INVALID'
+		if (!['single_use', 'effect'].includes(pos.slot.type)) result.push('INVALID_SLOT')
+		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
 		if (pos.slot.type === 'effect') {
-			if (!pos.row?.hermitCard) return 'INVALID'
+			if (!pos.row?.hermitCard) result.push('INVALID_SLOT')
 		}
 
-		return 'YES'
+		return result
 	}
 
 	// Allows placing in effect or single use slot

--- a/common/cards/default/effects/milk-bucket.ts
+++ b/common/cards/default/effects/milk-bucket.ts
@@ -25,7 +25,7 @@ class MilkBucketEffectCard extends EffectCard {
 				id: instance,
 				message: 'Pick one of your Hermits',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 					if (pickResult.rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
 
 					if (pickResult.slot.type !== 'hermit') return 'FAILURE_INVALID_SLOT'
@@ -101,9 +101,6 @@ class MilkBucketEffectCard extends EffectCard {
 		if (pos.player.id !== currentPlayer.id) return 'INVALID'
 		if (pos.slot.type === 'effect') {
 			if (!pos.row?.hermitCard) return 'INVALID'
-			const cardInfo = CARDS[pos.row.hermitCard?.cardId]
-			if (!cardInfo) return 'INVALID'
-			if (!cardInfo.canAttachToCard(game, pos)) return 'NO'
 		}
 
 		return 'YES'

--- a/common/cards/default/effects/water-bucket.ts
+++ b/common/cards/default/effects/water-bucket.ts
@@ -103,7 +103,7 @@ class WaterBucketEffectCard extends EffectCard {
 		if (!['single_use', 'effect'].includes(pos.slot.type)) result.push('INVALID_SLOT')
 		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
 		if (pos.slot.type === 'effect') {
-			if (!pos.row?.hermitCard) result.push('INVALID_SLOT')
+			if (!pos.row?.hermitCard) result.push('UNMET_CONDITION_SILENT')
 		}
 
 		return result

--- a/common/cards/default/effects/water-bucket.ts
+++ b/common/cards/default/effects/water-bucket.ts
@@ -26,7 +26,7 @@ class WaterBucketEffectCard extends EffectCard {
 				id: instance,
 				message: 'Pick one of your Hermits',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 					if (pickResult.rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
 
 					if (pickResult.slot.type !== 'hermit') return 'FAILURE_INVALID_SLOT'
@@ -102,9 +102,6 @@ class WaterBucketEffectCard extends EffectCard {
 		if (pos.player.id !== currentPlayer.id) return 'INVALID'
 		if (pos.slot.type === 'effect') {
 			if (!pos.row?.hermitCard) return 'INVALID'
-			const cardInfo = CARDS[pos.row.hermitCard?.cardId]
-			if (!cardInfo) return 'INVALID'
-			if (!cardInfo.canAttachToCard(game, pos)) return 'NO'
 		}
 
 		return 'YES'

--- a/common/cards/default/effects/water-bucket.ts
+++ b/common/cards/default/effects/water-bucket.ts
@@ -5,6 +5,7 @@ import {discardCard} from '../../../utils/movement'
 import EffectCard from '../../base/effect-card'
 import {CARDS} from '../..'
 import {applySingleUse, removeStatusEffect} from '../../../utils/board'
+import {CanAttachResult} from '../../base/card'
 
 class WaterBucketEffectCard extends EffectCard {
 	constructor() {
@@ -97,14 +98,15 @@ class WaterBucketEffectCard extends EffectCard {
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const {currentPlayer} = game
+		const result: CanAttachResult = []
 
-		if (!['single_use', 'effect'].includes(pos.slot.type)) return 'INVALID'
-		if (pos.player.id !== currentPlayer.id) return 'INVALID'
+		if (!['single_use', 'effect'].includes(pos.slot.type)) result.push('INVALID_SLOT')
+		if (pos.player.id !== currentPlayer.id) result.push('INVALID_PLAYER')
 		if (pos.slot.type === 'effect') {
-			if (!pos.row?.hermitCard) return 'INVALID'
+			if (!pos.row?.hermitCard) result.push('INVALID_SLOT')
 		}
 
-		return 'YES'
+		return result
 	}
 
 	// Allows placing in effect or single use slot

--- a/common/cards/default/effects/wolf.ts
+++ b/common/cards/default/effects/wolf.ts
@@ -18,10 +18,10 @@ class WolfEffectCard extends EffectCard {
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
 		const result = super.canAttach(game, pos)
-		const {currentPlayer} = game
+		const {player} = pos
 
 		// wolf addition - hermit must also be active to attach
-		if (!(currentPlayer.board.activeRow === pos.rowIndex)) result.push('INVALID_SLOT')
+		if (!(player.board.activeRow === pos.rowIndex)) result.push('INVALID_SLOT')
 
 		return result
 	}

--- a/common/cards/default/effects/wolf.ts
+++ b/common/cards/default/effects/wolf.ts
@@ -17,15 +17,13 @@ class WolfEffectCard extends EffectCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
+		const result = super.canAttach(game, pos)
 		const {currentPlayer} = game
 
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
 		// wolf addition - hermit must also be active to attach
-		if (!(currentPlayer.board.activeRow === pos.rowIndex)) return 'NO'
+		if (!(currentPlayer.board.activeRow === pos.rowIndex)) result.push('INVALID_SLOT')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/hermits/grian-rare.ts
+++ b/common/cards/default/hermits/grian-rare.ts
@@ -4,7 +4,7 @@ import {GameModel} from '../../../models/game-model'
 import {getActiveRowPos, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {flipCoin} from '../../../utils/coinFlips'
-import {canAttachToSlot, discardCard, exceptInvalidPlayer, swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, discardCard, swapSlots} from '../../../utils/movement'
 import HermitCard from '../../base/hermit-card'
 
 // The tricky part about this one are destroyable items (shield, totem, loyalty) since they are available at the moment of attack, but not after
@@ -61,9 +61,9 @@ class GrianRareHermitCard extends HermitCard {
 			if (coinFlip[0] === 'tails') return
 
 			const effectSlot = getSlotPos(player, rowIndex, 'effect')
-			const canAttachResult = canAttachToSlot(game, effectSlot, opponentEffectCard)
+			const canAttachResult = canAttachToSlot(game, effectSlot, opponentEffectCard, true)
 
-			if (canAttachResult.filter(exceptInvalidPlayer).length > 0) {
+			if (canAttachResult.length > 0) {
 				// We can't attach the new card, don't bother showing a modal
 				discardCard(game, opponentEffectCard, player)
 				return

--- a/common/cards/default/hermits/grian-rare.ts
+++ b/common/cards/default/hermits/grian-rare.ts
@@ -17,6 +17,7 @@ Some assumptions that make sense to me:
 - If you choose to discard the card it gets discarded to your discard pile
 */
 
+// @NOWTODO
 class GrianRareHermitCard extends HermitCard {
 	constructor() {
 		super({

--- a/common/cards/default/hermits/grian-rare.ts
+++ b/common/cards/default/hermits/grian-rare.ts
@@ -4,7 +4,7 @@ import {GameModel} from '../../../models/game-model'
 import {getActiveRowPos, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {flipCoin} from '../../../utils/coinFlips'
-import {canAttachToSlot, discardCard, swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, discardCard, exceptInvalidPlayer, swapSlots} from '../../../utils/movement'
 import HermitCard from '../../base/hermit-card'
 
 // The tricky part about this one are destroyable items (shield, totem, loyalty) since they are available at the moment of attack, but not after
@@ -17,7 +17,6 @@ Some assumptions that make sense to me:
 - If you choose to discard the card it gets discarded to your discard pile
 */
 
-// @NOWTODO
 class GrianRareHermitCard extends HermitCard {
 	constructor() {
 		super({
@@ -62,9 +61,9 @@ class GrianRareHermitCard extends HermitCard {
 			if (coinFlip[0] === 'tails') return
 
 			const effectSlot = getSlotPos(player, rowIndex, 'effect')
-			const canAttach = canAttachToSlot(game, effectSlot, opponentEffectCard)
+			const canAttachResult = canAttachToSlot(game, effectSlot, opponentEffectCard)
 
-			if (canAttach !== 'YES') {
+			if (canAttachResult.filter(exceptInvalidPlayer).length > 0) {
 				// We can't attach the new card, don't bother showing a modal
 				discardCard(game, opponentEffectCard, player)
 				return

--- a/common/cards/default/hermits/hypnotizd-rare.ts
+++ b/common/cards/default/hermits/hypnotizd-rare.ts
@@ -88,7 +88,7 @@ class HypnotizdRareHermitCard extends HermitCard {
 				id: this.id,
 				message: 'Choose an item to discard from your active Hermit.',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
@@ -119,7 +119,7 @@ class HypnotizdRareHermitCard extends HermitCard {
 				id: this.id,
 				message: "Pick one of your opponent's Hermits",
 				onResult(pickResult) {
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/hermits/ijevin-rare.ts
+++ b/common/cards/default/hermits/ijevin-rare.ts
@@ -44,7 +44,7 @@ class IJevinRareHermitCard extends HermitCard {
 					id: this.id,
 					message: 'Choose a new active Hermit from your afk Hermits.',
 					onResult(pickResult) {
-						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 						const rowIndex = pickResult.rowIndex
 						if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/hermits/rendog-rare.ts
+++ b/common/cards/default/hermits/rendog-rare.ts
@@ -79,7 +79,7 @@ class RendogRareHermitCard extends HermitCard {
 				id: this.id,
 				message: "Pick one of your opponent's Hermits",
 				onResult(pickResult) {
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/hermits/tangotek-rare.ts
+++ b/common/cards/default/hermits/tangotek-rare.ts
@@ -54,7 +54,7 @@ class TangoTekRareHermitCard extends HermitCard {
 					message: 'Pick a new active Hermit from your afk hermits',
 					onResult(pickResult) {
 						// Validation
-						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 						if (pickResult.rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
 						if (pickResult.slot.type !== 'hermit') return 'FAILURE_INVALID_SLOT'
 						if (pickResult.card === null) return 'FAILURE_INVALID_SLOT'
@@ -89,7 +89,7 @@ class TangoTekRareHermitCard extends HermitCard {
 					message: 'Pick a new active Hermit from your afk hermits',
 					onResult(pickResult) {
 						// Validation
-						if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+						if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 						if (pickResult.rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
 						if (pickResult.slot.type !== 'hermit') return 'FAILURE_INVALID_SLOT'
 						if (pickResult.card === null) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/hermits/zombiecleo-rare.ts
+++ b/common/cards/default/hermits/zombiecleo-rare.ts
@@ -80,7 +80,7 @@ class ZombieCleoRareHermitCard extends HermitCard {
 				id: this.id,
 				message: 'Pick one of your AFK Hermits',
 				onResult(pickResult) {
-					if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/bow.ts
+++ b/common/cards/default/single-use/bow.ts
@@ -39,7 +39,7 @@ class BowSingleUseCard extends SingleUseCard {
 				id: this.id,
 				message: "Pick one of your opponent's AFK Hermits",
 				onResult(pickResult) {
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/bow.ts
+++ b/common/cards/default/single-use/bow.ts
@@ -17,16 +17,14 @@ class BowSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {opponentPlayer} = pos
 
 		// Check if there is an AFK Hermit
 		const inactiveRows = getNonEmptyRows(opponentPlayer, true)
-		if (inactiveRows.length === 0) return 'NO'
+		if (inactiveRows.length === 0) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/chest.ts
+++ b/common/cards/default/single-use/chest.ts
@@ -17,14 +17,12 @@ class ChestSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {player} = pos
-		// Cannot play chest with no items in discard
-		if (player.discarded.length <= 0) return 'NO'
 
-		return 'YES'
+		if (player.discarded.length <= 0) result.push('UNMET_CONDITION')
+
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/chorus-fruit.ts
+++ b/common/cards/default/single-use/chorus-fruit.ts
@@ -34,8 +34,7 @@ class ChorusFruitSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const {player} = pos
 		const activeRow = getActiveRow(player)
@@ -44,9 +43,9 @@ class ChorusFruitSingleUseCard extends SingleUseCard {
 			(a) =>
 				a.targetInstance == activeRow?.hermitCard?.cardInstance && a.statusEffectId == 'sleeping'
 		)
-		if (isSleeping) return 'NO'
+		if (isSleeping) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/clock.ts
+++ b/common/cards/default/single-use/clock.ts
@@ -45,17 +45,16 @@ class ClockSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
+		const result = super.canAttach(game, pos)
 
 		if (game.state.statusEffects.some((effect) => effect.statusEffectId === 'used-clock')) {
-			return 'INVALID'
+			result.push('UNMET_CONDITION')
 		}
 
-		if (canAttach !== 'YES') return canAttach
-
 		// The other player wouldn't be able to attach anything
-		if (game.state.turn.turnNumber === 1) return 'NO'
-		return 'YES'
+		if (game.state.turn.turnNumber === 1) result.push('UNMET_CONDITION')
+
+		return result
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/composter.ts
+++ b/common/cards/default/single-use/composter.ts
@@ -19,13 +19,13 @@ class ComposterSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {player} = pos
-		if (player.hand.length < 2) return 'NO'
 
-		return 'YES'
+		if (player.hand.length < 2) result.push('UNMET_CONDITION')
+		if (player.pile.length <= 2) result.push('UNMET_CONDITION')
+
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/composter.ts
+++ b/common/cards/default/single-use/composter.ts
@@ -37,7 +37,7 @@ class ComposterSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick 2 cards from your hand',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				if (pickResult.slot.type !== 'hand') return 'FAILURE_INVALID_SLOT'
 				if (!pickResult.card) return 'FAILURE_INVALID_SLOT'
@@ -57,7 +57,7 @@ class ComposterSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick 1 more card from your hand',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				if (pickResult.slot.type !== 'hand') return 'FAILURE_INVALID_SLOT'
 				if (!pickResult.card) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/crossbow.ts
+++ b/common/cards/default/single-use/crossbow.ts
@@ -33,7 +33,7 @@ class CrossbowSingleUseCard extends SingleUseCard {
 				id: this.id,
 				message: "Pick {?} of your opponent's Hermits",
 				onResult(pickResult) {
-					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+					if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 					const rowIndex = pickResult.rowIndex
 					if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/curse-of-vanishing.ts
+++ b/common/cards/default/single-use/curse-of-vanishing.ts
@@ -1,5 +1,6 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
+import {getActiveRow} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {discardCard} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
@@ -32,16 +33,20 @@ class CurseOfVanishingSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const {opponentPlayer} = pos
 
-		if (opponentPlayer.board.activeRow === null) return 'NO'
-		const opponentActiveRow = opponentPlayer.board.rows[opponentPlayer.board.activeRow]
-		if (!opponentActiveRow.effectCard || !isRemovable(opponentActiveRow.effectCard)) return 'NO'
+		const opponentActiveRow = getActiveRow(opponentPlayer)
+		if (
+			!opponentActiveRow ||
+			!opponentActiveRow.effectCard ||
+			!isRemovable(opponentActiveRow.effectCard)
+		) {
+			result.push('UNMET_CONDITION')
+		}
 
-		return 'YES'
+		return result
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/emerald.ts
+++ b/common/cards/default/single-use/emerald.ts
@@ -1,10 +1,11 @@
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {canAttachToCard, getSlotPos} from '../../../utils/board'
+import {getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {canAttachToSlot, swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
 
+// @NOWTODO
 class EmeraldSingleUseCard extends SingleUseCard {
 	constructor() {
 		super({
@@ -31,8 +32,6 @@ class EmeraldSingleUseCard extends SingleUseCard {
 
 		const opponentEffect = opponentActiveRow.effectCard
 		const playerEffect = playerActiveRow.effectCard
-		const opponentHermit = opponentActiveRow.hermitCard
-		const playerHermit = playerActiveRow.hermitCard
 
 		// If either card can't be placed in the other slot, don't attach
 		const playerEffectSlot = getSlotPos(player, playerActiveRowIndex, 'effect')
@@ -40,13 +39,11 @@ class EmeraldSingleUseCard extends SingleUseCard {
 
 		if (playerEffect) {
 			if (canAttachToSlot(game, opponentEffectSlot, playerEffect) !== 'YES') return 'NO'
-			if (!canAttachToCard(game, playerEffect, opponentHermit)) return 'NO'
 			if (!isRemovable(playerEffect)) return 'NO'
 		}
 
 		if (opponentEffect) {
 			if (canAttachToSlot(game, playerEffectSlot, opponentEffect) !== 'YES') return 'NO'
-			if (!canAttachToCard(game, opponentEffect, playerHermit)) return 'NO'
 			if (!isRemovable(opponentEffect)) return 'NO'
 		}
 

--- a/common/cards/default/single-use/emerald.ts
+++ b/common/cards/default/single-use/emerald.ts
@@ -2,10 +2,10 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
-import {canAttachToSlot, swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, exceptInvalidPlayer, swapSlots} from '../../../utils/movement'
+import {CanAttachResult} from '../../base/card'
 import SingleUseCard from '../../base/single-use-card'
 
-// @NOWTODO
 class EmeraldSingleUseCard extends SingleUseCard {
 	constructor() {
 		super({
@@ -17,37 +17,40 @@ class EmeraldSingleUseCard extends SingleUseCard {
 		})
 	}
 
-	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+	override canAttach(game: GameModel, pos: CardPosModel): CanAttachResult {
+		const result = super.canAttach(game, pos)
 
 		const {player, opponentPlayer} = pos
 		const playerActiveRowIndex = player.board.activeRow
 		const opponentActiveRowIndex = opponentPlayer.board.activeRow
 
-		if (playerActiveRowIndex === null || opponentActiveRowIndex === null) return 'NO'
+		if (playerActiveRowIndex === null || opponentActiveRowIndex === null) {
+			result.push('UNMET_CONDITION')
+		} else {
+			const opponentActiveRow = opponentPlayer.board.rows[opponentActiveRowIndex]
+			const playerActiveRow = player.board.rows[playerActiveRowIndex]
 
-		const opponentActiveRow = opponentPlayer.board.rows[opponentActiveRowIndex]
-		const playerActiveRow = player.board.rows[playerActiveRowIndex]
+			const opponentEffect = opponentActiveRow.effectCard
+			const playerEffect = playerActiveRow.effectCard
 
-		const opponentEffect = opponentActiveRow.effectCard
-		const playerEffect = playerActiveRow.effectCard
+			// If either card can't be placed in the other slot, don't attach
+			const playerEffectSlot = getSlotPos(player, playerActiveRowIndex, 'effect')
+			const opponentEffectSlot = getSlotPos(opponentPlayer, opponentActiveRowIndex, 'effect')
 
-		// If either card can't be placed in the other slot, don't attach
-		const playerEffectSlot = getSlotPos(player, playerActiveRowIndex, 'effect')
-		const opponentEffectSlot = getSlotPos(opponentPlayer, opponentActiveRowIndex, 'effect')
+			if (playerEffect) {
+				const canAttach = canAttachToSlot(game, opponentEffectSlot, playerEffect)
+				if (canAttach.filter(exceptInvalidPlayer).length > 0) result.push('UNMET_CONDITION')
+				if (!isRemovable(playerEffect)) result.push('UNMET_CONDITION')
+			}
 
-		if (playerEffect) {
-			if (canAttachToSlot(game, opponentEffectSlot, playerEffect) !== 'YES') return 'NO'
-			if (!isRemovable(playerEffect)) return 'NO'
+			if (opponentEffect) {
+				const canAttach = canAttachToSlot(game, playerEffectSlot, opponentEffect)
+				if (canAttach.filter(exceptInvalidPlayer).length > 0) result.push('UNMET_CONDITION')
+				if (!isRemovable(opponentEffect)) result.push('UNMET_CONDITION')
+			}
 		}
 
-		if (opponentEffect) {
-			if (canAttachToSlot(game, playerEffectSlot, opponentEffect) !== 'YES') return 'NO'
-			if (!isRemovable(opponentEffect)) return 'NO'
-		}
-
-		return 'YES'
+		return result
 	}
 
 	override canApply() {

--- a/common/cards/default/single-use/emerald.ts
+++ b/common/cards/default/single-use/emerald.ts
@@ -2,7 +2,7 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
-import {canAttachToSlot, exceptInvalidPlayer, swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, swapSlots} from '../../../utils/movement'
 import {CanAttachResult} from '../../base/card'
 import SingleUseCard from '../../base/single-use-card'
 
@@ -38,14 +38,14 @@ class EmeraldSingleUseCard extends SingleUseCard {
 			const opponentEffectSlot = getSlotPos(opponentPlayer, opponentActiveRowIndex, 'effect')
 
 			if (playerEffect) {
-				const canAttach = canAttachToSlot(game, opponentEffectSlot, playerEffect)
-				if (canAttach.filter(exceptInvalidPlayer).length > 0) result.push('UNMET_CONDITION')
+				const canAttach = canAttachToSlot(game, opponentEffectSlot, playerEffect, true)
+				if (canAttach.length > 0) result.push('UNMET_CONDITION')
 				if (!isRemovable(playerEffect)) result.push('UNMET_CONDITION')
 			}
 
 			if (opponentEffect) {
-				const canAttach = canAttachToSlot(game, playerEffectSlot, opponentEffect)
-				if (canAttach.filter(exceptInvalidPlayer).length > 0) result.push('UNMET_CONDITION')
+				const canAttach = canAttachToSlot(game, playerEffectSlot, opponentEffect, true)
+				if (canAttach.length > 0) result.push('UNMET_CONDITION')
 				if (!isRemovable(opponentEffect)) result.push('UNMET_CONDITION')
 			}
 		}

--- a/common/cards/default/single-use/fishing-rod.ts
+++ b/common/cards/default/single-use/fishing-rod.ts
@@ -15,13 +15,12 @@ class FishingRodSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {player} = pos
-		if (player.pile.length <= 2) return 'NO'
 
-		return 'YES'
+		if (player.pile.length <= 2) result.push('UNMET_CONDITION')
+
+		return result
 	}
 
 	override canApply() {

--- a/common/cards/default/single-use/flint-and-steel.ts
+++ b/common/cards/default/single-use/flint-and-steel.ts
@@ -16,13 +16,12 @@ class FlintAndSteelSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {player} = pos
-		if (player.pile.length <= 3) return 'NO'
 
-		return 'YES'
+		if (player.pile.length <= 3) result.push('UNMET_CONDITION')
+
+		return result
 	}
 
 	override canApply() {

--- a/common/cards/default/single-use/golden-apple.ts
+++ b/common/cards/default/single-use/golden-apple.ts
@@ -17,21 +17,20 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
 		const {player} = pos
 
 		// Need active hermit to play
-		if (!isActive(player)) return 'NO'
+		if (!isActive(player)) result.push('UNMET_CONDITION')
 
 		// Can't attach it there are not any inactive hermits
 		const playerHasAfk = getNonEmptyRows(player, true).some(
 			(rowPos) => HERMIT_CARDS[rowPos.row.hermitCard.cardId] !== undefined
 		)
-		if (!playerHasAfk) return 'NO'
+		if (!playerHasAfk) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/golden-apple.ts
+++ b/common/cards/default/single-use/golden-apple.ts
@@ -2,7 +2,7 @@ import SingleUseCard from '../../base/single-use-card'
 import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
-import {isActive} from '../../../utils/game'
+import {hasActive} from '../../../utils/game'
 import {applySingleUse, getNonEmptyRows} from '../../../utils/board'
 
 class GoldenAppleSingleUseCard extends SingleUseCard {
@@ -22,7 +22,7 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 		const {player} = pos
 
 		// Need active hermit to play
-		if (!isActive(player)) result.push('UNMET_CONDITION')
+		if (!hasActive(player)) result.push('UNMET_CONDITION')
 
 		// Can't attach it there are not any inactive hermits
 		const playerHasAfk = getNonEmptyRows(player, true).some(

--- a/common/cards/default/single-use/golden-apple.ts
+++ b/common/cards/default/single-use/golden-apple.ts
@@ -42,7 +42,7 @@ class GoldenAppleSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick one of your AFK Hermits',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/instant-health-ii.ts
+++ b/common/cards/default/single-use/instant-health-ii.ts
@@ -17,18 +17,16 @@ class InstantHealthIISingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {player} = pos
 
 		// Can't attach it there are no real hermits
 		const playerHasHermit = getNonEmptyRows(player).some(
 			(rowPos) => HERMIT_CARDS[rowPos.row.hermitCard.cardId] !== undefined
 		)
-		if (!playerHasHermit) return 'NO'
+		if (!playerHasHermit) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/instant-health-ii.ts
+++ b/common/cards/default/single-use/instant-health-ii.ts
@@ -39,7 +39,7 @@ class InstantHealthIISingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick an active or AFK Hermit',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/instant-health-ii.ts
+++ b/common/cards/default/single-use/instant-health-ii.ts
@@ -3,7 +3,6 @@ import {HERMIT_CARDS} from '../..'
 import {GameModel} from '../../../models/game-model'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {applySingleUse, getNonEmptyRows} from '../../../utils/board'
-import {isActive} from '../../../utils/game'
 
 class InstantHealthIISingleUseCard extends SingleUseCard {
 	constructor() {

--- a/common/cards/default/single-use/instant-health.ts
+++ b/common/cards/default/single-use/instant-health.ts
@@ -38,7 +38,7 @@ class InstantHealthSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: 'Pick an active or AFK Hermit',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/instant-health.ts
+++ b/common/cards/default/single-use/instant-health.ts
@@ -16,18 +16,16 @@ class InstantHealthSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {player} = pos
 
 		// Can't attach it there are no real hermits
 		const playerHasHermit = getNonEmptyRows(player).some(
 			(rowPos) => HERMIT_CARDS[rowPos.row.hermitCard.cardId] !== undefined
 		)
-		if (!playerHasHermit) return 'NO'
+		if (!playerHasHermit) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/knockback.ts
+++ b/common/cards/default/single-use/knockback.ts
@@ -16,16 +16,14 @@ class KnockbackSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+		const result = super.canAttach(game, pos)
 		const {opponentPlayer} = pos
 
 		// Check if there is an AFK Hermit
 		const inactiveRows = getNonEmptyRows(opponentPlayer, true)
-		if (inactiveRows.length === 0) return 'NO'
+		if (inactiveRows.length === 0) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/knockback.ts
+++ b/common/cards/default/single-use/knockback.ts
@@ -54,7 +54,7 @@ class KnockbackSingleUseCard extends SingleUseCard {
 					id: this.id,
 					message: 'Choose a new active Hermit from your afk Hermits',
 					onResult(pickResult) {
-						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+						if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 						const rowIndex = pickResult.rowIndex
 						if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'

--- a/common/cards/default/single-use/lava-bucket.ts
+++ b/common/cards/default/single-use/lava-bucket.ts
@@ -34,11 +34,11 @@ class LavaBucketSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		if (pos.slot.type !== 'single_use') return 'INVALID'
+		const result = super.canAttach(game, pos)
 
-		if (pos.opponentPlayer.board.activeRow === null) return 'NO'
+		if (pos.opponentPlayer.board.activeRow === null) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/lead.ts
+++ b/common/cards/default/single-use/lead.ts
@@ -3,7 +3,6 @@ import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
 import {
 	applySingleUse,
-	canAttachToCard,
 	getActiveRow,
 	getActiveRowPos,
 	getRowsWithEmptyItemsSlots,
@@ -13,6 +12,7 @@ import {
 import {swapSlots} from '../../../utils/movement'
 import SingleUseCard from '../../base/single-use-card'
 
+// @NOWTODO
 class LeadSingleUseCard extends SingleUseCard {
 	constructor() {
 		super({
@@ -36,12 +36,7 @@ class LeadSingleUseCard extends SingleUseCard {
 		const rowsWithEmptySlots = getRowsWithEmptyItemsSlots(opponentPlayer, true)
 		if (rowsWithEmptySlots.length === 0) return 'NO'
 
-		// check if the card can be attached to any of the inactive hermits
-		for (const row of rowsWithEmptySlots) {
-			for (const item of activeRow.itemCards) {
-				if (canAttachToCard(game, row.hermitCard, item)) return 'YES'
-			}
-		}
+		//@NOWTODO check canAttachToSlot
 
 		return 'NO'
 	}
@@ -55,7 +50,7 @@ class LeadSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: "Pick an item card attached to your opponent's active Hermit",
 			onResult(pickResult) {
-				if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
@@ -75,7 +70,7 @@ class LeadSingleUseCard extends SingleUseCard {
 			id: this.id,
 			message: "Pick an empty item slot on one of your opponent's AFK Hermits",
 			onResult(pickResult) {
-				if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== opponentPlayer.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
@@ -100,8 +95,8 @@ class LeadSingleUseCard extends SingleUseCard {
 				}
 
 				// Make sure we can attach the item
+				// @NOWTODO need to call canAttachToSlot
 				const itemCard = opponentActivePos.row.itemCards[itemIndex]
-				if (!canAttachToCard(game, row.hermitCard, itemCard)) return 'FAILURE_INVALID_SLOT'
 
 				// Move the item
 				const itemPos = getSlotPos(opponentPlayer, opponentActivePos.rowIndex, 'item', itemIndex)

--- a/common/cards/default/single-use/lead.ts
+++ b/common/cards/default/single-use/lead.ts
@@ -5,14 +5,15 @@ import {
 	applySingleUse,
 	getActiveRow,
 	getActiveRowPos,
-	getRowsWithEmptyItemsSlots,
+	getNonEmptyRows,
 	getSlotPos,
+	rowHasEmptyItemSlot,
 	rowHasItem,
 } from '../../../utils/board'
-import {swapSlots} from '../../../utils/movement'
+import {canAttachToSlot, swapSlots} from '../../../utils/movement'
+import {CanAttachResult} from '../../base/card'
 import SingleUseCard from '../../base/single-use-card'
 
-// @NOWTODO
 class LeadSingleUseCard extends SingleUseCard {
 	constructor() {
 		super({
@@ -25,20 +26,36 @@ class LeadSingleUseCard extends SingleUseCard {
 		})
 	}
 
-	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
-
+	override canAttach(game: GameModel, pos: CardPosModel): CanAttachResult {
+		const result = super.canAttach(game, pos)
 		const {opponentPlayer} = pos
 
 		const activeRow = getActiveRow(opponentPlayer)
-		if (!activeRow || !rowHasItem(activeRow)) return 'NO'
-		const rowsWithEmptySlots = getRowsWithEmptyItemsSlots(opponentPlayer, true)
-		if (rowsWithEmptySlots.length === 0) return 'NO'
+		if (!activeRow || !rowHasItem(activeRow)) return [...result, 'UNMET_CONDITION']
 
-		//@NOWTODO check canAttachToSlot
+		const afkRows = getNonEmptyRows(opponentPlayer, true)
 
-		return 'NO'
+		const items = activeRow.itemCards
+		// Check all afk rows for each item card against all empty slots on that row
+		for (let rowIndex = 0; rowIndex < afkRows.length; rowIndex++) {
+			const rowPos = afkRows[rowIndex]
+			if (!rowHasEmptyItemSlot(rowPos.row)) continue
+
+			for (const item of items) {
+				if (!item) continue
+
+				for (let i = 0; i < 3; i++) {
+					const targetSlot = getSlotPos(opponentPlayer, rowIndex, 'item', i)
+
+					if (canAttachToSlot(game, targetSlot, item, true).length > 0) continue
+
+					// We're good to place
+					return result
+				}
+			}
+		}
+
+		return [...result, 'UNMET_CONDITION']
 	}
 
 	override onAttach(game: GameModel, instance: string, pos: CardPosModel) {
@@ -95,12 +112,14 @@ class LeadSingleUseCard extends SingleUseCard {
 				}
 
 				// Make sure we can attach the item
-				// @NOWTODO need to call canAttachToSlot
-				const itemCard = opponentActivePos.row.itemCards[itemIndex]
-
-				// Move the item
 				const itemPos = getSlotPos(opponentPlayer, opponentActivePos.rowIndex, 'item', itemIndex)
 				const targetPos = getSlotPos(opponentPlayer, rowIndex, 'item', pickResult.slot.index)
+				const itemCard = opponentActivePos.row.itemCards[itemIndex]
+				if (canAttachToSlot(game, targetPos, itemCard!, true).length > 0) {
+					return 'FAILURE_INVALID_SLOT'
+				}
+
+				// Move the item
 				swapSlots(game, itemPos, targetPos)
 
 				const cardInfo = CARDS[itemCard!.cardId]

--- a/common/cards/default/single-use/mending.ts
+++ b/common/cards/default/single-use/mending.ts
@@ -1,11 +1,12 @@
 import {CARDS} from '../..'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {applySingleUse, canAttachToCard, getActiveRow, getNonEmptyRows, getSlotPos} from '../../../utils/board'
+import {applySingleUse, getActiveRow, getNonEmptyRows, getSlotPos} from '../../../utils/board'
 import {isRemovable} from '../../../utils/cards'
 import {canAttachToSlot, discardSingleUse, swapSlots} from '../../../utils/movement'
 import singleUseCard from '../../base/single-use-card'
 
+// @NOWTODO
 class MendingSingleUseCard extends singleUseCard {
 	constructor() {
 		super({
@@ -31,12 +32,10 @@ class MendingSingleUseCard extends singleUseCard {
 		const inactiveRows = getNonEmptyRows(player, true)
 		for (const rowPos of inactiveRows) {
 			if (rowPos.row.effectCard) continue
-
-			const attachToCard = canAttachToCard(game, rowPos.row.hermitCard, effectCard);
 			const slotPos = getSlotPos(player, rowPos.rowIndex, 'effect')
 			const attachToSlot = canAttachToSlot(game, slotPos, effectCard)
 
-			if (attachToCard && attachToSlot) return 'YES'
+			// @NOWTODO
 		}
 
 		return 'NO'
@@ -67,7 +66,7 @@ class MendingSingleUseCard extends singleUseCard {
 			id: this.id,
 			message: 'Pick an empty effect slot from one of your afk Hermits',
 			onResult(pickResult) {
-				if (pickResult.playerId !== player.id) return 'FAILURE_WRONG_PLAYER'
+				if (pickResult.playerId !== player.id) return 'FAILURE_INVALID_PLAYER'
 
 				const rowIndex = pickResult.rowIndex
 				if (rowIndex === undefined) return 'FAILURE_INVALID_SLOT'
@@ -79,7 +78,7 @@ class MendingSingleUseCard extends singleUseCard {
 				const row = player.board.rows[rowIndex]
 				if (!row.hermitCard) return 'FAILURE_INVALID_SLOT'
 
-				if (!canAttachToCard(game, row.hermitCard, effectCard)) return 'FAILURE_CANNOT_COMPLETE'
+				// @NOWTODO check canAttachToSlot
 
 				// Apply the mending card
 				applySingleUse(game, [

--- a/common/cards/default/single-use/splash-potion-of-poison.ts
+++ b/common/cards/default/single-use/splash-potion-of-poison.ts
@@ -34,12 +34,11 @@ class SplashPotionOfPoisonSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 
-		if (pos.opponentPlayer.board.activeRow === null) return 'NO'
+		if (pos.opponentPlayer.board.activeRow === null) result.push('UNMET_CONDITION')
 
-		return 'YES'
+		return result
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/cards/default/single-use/spyglass.ts
+++ b/common/cards/default/single-use/spyglass.ts
@@ -64,17 +64,13 @@ class SpyglassSingleUseCard extends SingleUseCard {
 	}
 
 	override canAttach(game: GameModel, pos: CardPosModel) {
-		const canAttach = super.canAttach(game, pos)
-		if (canAttach !== 'YES') return canAttach
+		const result = super.canAttach(game, pos)
 		const {opponentPlayer} = pos
 
-		// Gem can use 2 spyglasses on the same turn
-		if (opponentPlayer.hand.length === 0) return 'NO'
+		if (opponentPlayer.hand.length === 0) result.push('UNMET_CONDITION')
+		if (game.state.turn.turnNumber === 1) result.push('UNMET_CONDITION')
 
-		// They can discard the only hermit in their hand
-		if (game.state.turn.turnNumber === 1) return 'NO'
-
-		return 'YES'
+		return result
 	}
 
 	override onDetach(game: GameModel, instance: string, pos: CardPosModel) {

--- a/common/types/game-state.ts
+++ b/common/types/game-state.ts
@@ -1,3 +1,4 @@
+import {CanAttachResult} from '../cards/base/card'
 import {AttackModel} from '../models/attack-model'
 import {BattleLog} from '../models/battle-log'
 import {CardPosModel} from '../models/card-pos-model'
@@ -91,6 +92,8 @@ export type PlayerState = {
 		/** Hook that modifies and returns blockedActions */
 		blockedActions: WaterfallHook<(blockedActions: TurnActions) => TurnActions>
 
+		/** Hook called when checking if a card can be attached. The result can be modified and will be stored */
+		canAttach: GameHook<(canAttach: CanAttachResult, pos: CardPosModel) => void>
 		/** Hook called when a card is attached */
 		onAttach: GameHook<(instance: string) => void>
 		/** Hook called when a card is detached */
@@ -157,7 +160,7 @@ export type PlayerState = {
 		beforeActiveRowChange: GameHook<(oldRow: number | null, newRow: number | null) => boolean>
 		/** Hook called when the active row is changed. */
 		onActiveRowChange: GameHook<(oldRow: number | null, newRow: number | null) => void>
-		// @TODO this is currently not complete, it needs to be called in a lot more places, if it is needed
+		// @TODO replace with canDetach, we already have canAttach
 		/** Hook called when a card attemps to move or rows are swapped. Returns whether the card in this position can be moved, or if the slot is empty, if it can be moved to. */
 		onSlotChange: GameHook<(slot: SlotPos) => boolean>
 	}
@@ -171,11 +174,15 @@ export type GenericActionResult =
 	| 'FAILURE_CANNOT_COMPLETE'
 	| 'FAILURE_UNKNOWN_ERROR'
 
-export type PlayCardActionResult = 'FAILURE_INVALID_SLOT' | 'FAILURE_CANNOT_ATTACH'
+export type PlayCardActionResult =
+	| 'FAILURE_INVALID_PLAYER'
+	| 'FAILURE_INVALID_SLOT'
+	| 'FAILURE_UNMET_CONDITION'
+	| 'FAILURE_UNMET_CONDITION_SILENT'
 
 export type PickCardActionResult =
+	| 'FAILURE_INVALID_PLAYER'
 	| 'FAILURE_INVALID_SLOT'
-	| 'FAILURE_WRONG_PLAYER'
 	| 'FAILURE_WRONG_PICK'
 
 export type ActionResult = GenericActionResult | PlayCardActionResult | PickCardActionResult

--- a/common/utils/board.ts
+++ b/common/utils/board.ts
@@ -43,7 +43,12 @@ export function getRowPos(cardPos: CardPosModel): RowPos | null {
 	}
 }
 
-export function getSlotPos(player: PlayerState, rowIndex: number, type: BoardSlotTypeT, index = 0): SlotPos {
+export function getSlotPos(
+	player: PlayerState,
+	rowIndex: number,
+	type: BoardSlotTypeT,
+	index = 0
+): SlotPos {
 	return {
 		player,
 		rowIndex,
@@ -211,20 +216,4 @@ export function removeStatusEffect(
 	game.state.statusEffects = game.state.statusEffects.filter((a) => !statusEffects.includes(a))
 
 	return 'SUCCESS'
-}
-
-export function canAttachToCard(
-	game: GameModel,
-	card: CardT | null,
-	cardAttaching: CardT | null
-): boolean {
-	if (!card || !cardAttaching) return false
-
-	const cardAttachingPos = getCardPos(game, cardAttaching.cardInstance)
-	const cardInfo = CARDS[card.cardId]
-	if (!cardAttachingPos || !cardInfo) return false
-
-	if (!cardInfo.canAttachToCard(game, cardAttachingPos)) return false
-
-	return true
 }

--- a/common/utils/game.ts
+++ b/common/utils/game.ts
@@ -1,6 +1,6 @@
 import {GameModel} from '../models/game-model'
 import {TurnAction, PlayerState} from '../types/game-state'
 
-export function isActive(playerState: PlayerState): boolean {
+export function hasActive(playerState: PlayerState): boolean {
 	return playerState.board.activeRow !== null
 }

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -5,6 +5,7 @@ import {BasicCardPos, CardPosModel, getCardPos} from '../models/card-pos-model'
 import {equalCard} from './cards'
 import {SlotPos} from '../types/cards'
 import {getSlotPos} from './board'
+import {CanAttachResult} from '../cards/base/card'
 
 function discardAtPos(pos: CardPosModel) {
 	const {player, row, slot} = pos
@@ -177,23 +178,27 @@ export function getSlotCard(slotPos: SlotPos): CardT | null {
 	return row.itemCards[index]
 }
 
-export function canAttachToSlot(game: GameModel, slotPos: SlotPos, card: CardT) {
+export function canAttachToSlot(game: GameModel, slotPos: SlotPos, card: CardT): CanAttachResult {
+	const {player, rowIndex, row, slot} = slotPos
 	const opponentPlayerId = game.getPlayerIds().find((id) => id !== slotPos.player.id)
-	if (!opponentPlayerId) return 'INVALID'
+	if (!opponentPlayerId) return ['UNKNOWN_ERROR']
 
 	const basicPos: BasicCardPos = {
-		player: slotPos.player,
+		player,
 		opponentPlayer: game.state.players[opponentPlayerId],
-		rowIndex: slotPos.rowIndex,
-		row: slotPos.row,
-		slot: slotPos.slot,
+		rowIndex,
+		row,
+		slot,
 	}
 
 	// Create a fake card pos model
 	const pos = new CardPosModel(game, basicPos, card.cardInstance, true)
 
 	const cardInfo = CARDS[card.cardId]
-	return cardInfo.canAttach(game, pos)
+	const canAttach = cardInfo.canAttach(game, pos)
+	player.hooks.canAttach.call(canAttach, pos)
+
+	return canAttach
 }
 
 /** Swaps the positions of two cards on the board. Returns whether or not the swap was successful. */
@@ -210,19 +215,33 @@ export function swapSlots(
 	// Info about non-empty slots
 	let cardsInfo: any = []
 
+	// Make sure each card can be placed in the other slot
+	const cardA = getSlotCard(slotAPos)
+	const cardB = getSlotCard(slotBPos)
+	if (cardB) {
+		// Return false if we cabn't attach for any reason other than wrong player
+		const canAttachResult = canAttachToSlot(game, slotAPos, cardB).filter(
+			(result) => result !== 'INVALID_PLAYER'
+		)
+		if (canAttachResult.length > 0) return false
+	}
+	if (cardA) {
+		// Return false if we cabn't attach for any reason other than wrong player
+		const canAttachResult = canAttachToSlot(game, slotBPos, cardA).filter(
+			(result) => result !== 'INVALID_PLAYER'
+		)
+		if (canAttachResult.length > 0) return false
+	}
+
 	// make checks for each slot and then detach
 	const slots = [slotAPos, slotBPos]
 	for (let i = 0; i < slots.length; i++) {
 		const slot = slots[i]
-		const otherSlot = slots[(i + 1) % 2]
 
 		if (isSlotEmpty(slot)) continue
 
 		const card = getSlotCard(slot)
 		if (!card) continue
-
-		// Make sure this card can be placed in the other slot
-		if (canAttachToSlot(game, otherSlot, card) !== 'YES') return false
 
 		const cardPos = getCardPos(game, card.cardInstance)
 		if (!cardPos) continue

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -202,7 +202,7 @@ export function canAttachToSlot(game: GameModel, slotPos: SlotPos, card: CardT):
 }
 
 /** Filters a `CanAttachResult` to remove all `'INVALID_PLAYER'` problems for movement checks */
-function exceptInvalidPlayer(
+export function exceptInvalidPlayer(
 	result: CanAttachResult[number]
 ): result is Exclude<typeof result, 'INVALID_PLAYER'> {
 	return result !== 'INVALID_PLAYER'

--- a/common/utils/movement.ts
+++ b/common/utils/movement.ts
@@ -201,6 +201,13 @@ export function canAttachToSlot(game: GameModel, slotPos: SlotPos, card: CardT):
 	return canAttach
 }
 
+/** Filters a `CanAttachResult` to remove all `'INVALID_PLAYER'` problems for movement checks */
+function exceptInvalidPlayer(
+	result: CanAttachResult[number]
+): result is Exclude<typeof result, 'INVALID_PLAYER'> {
+	return result !== 'INVALID_PLAYER'
+}
+
 /** Swaps the positions of two cards on the board. Returns whether or not the swap was successful. */
 export function swapSlots(
 	game: GameModel,
@@ -219,17 +226,13 @@ export function swapSlots(
 	const cardA = getSlotCard(slotAPos)
 	const cardB = getSlotCard(slotBPos)
 	if (cardB) {
-		// Return false if we cabn't attach for any reason other than wrong player
-		const canAttachResult = canAttachToSlot(game, slotAPos, cardB).filter(
-			(result) => result !== 'INVALID_PLAYER'
-		)
+		// Return false if we can't attach for any reason other than wrong player
+		const canAttachResult = canAttachToSlot(game, slotAPos, cardB).filter(exceptInvalidPlayer)
 		if (canAttachResult.length > 0) return false
 	}
 	if (cardA) {
-		// Return false if we cabn't attach for any reason other than wrong player
-		const canAttachResult = canAttachToSlot(game, slotBPos, cardA).filter(
-			(result) => result !== 'INVALID_PLAYER'
-		)
+		// Return false if we can't attach for any reason other than wrong player
+		const canAttachResult = canAttachToSlot(game, slotBPos, cardA).filter(exceptInvalidPlayer)
 		if (canAttachResult.length > 0) return false
 	}
 

--- a/server/src/routines/turn-actions/play-card.ts
+++ b/server/src/routines/turn-actions/play-card.ts
@@ -66,6 +66,8 @@ function* playCardSaga(
 	if (canAttach.includes('UNMET_CONDITION_SILENT')) return 'FAILURE_UNMET_CONDITION_SILENT'
 	if (canAttach.includes('UNMET_CONDITION')) return 'FAILURE_UNMET_CONDITION'
 
+	if (canAttach.includes('UNKNOWN_ERROR')) return 'FAILURE_UNKNOWN_ERROR'
+
 	// Finally, execute depending on where we tried to place
 	// And set the action result to be sent to the client
 

--- a/server/src/routines/turn-actions/play-card.ts
+++ b/server/src/routines/turn-actions/play-card.ts
@@ -57,11 +57,14 @@ function* playCardSaga(
 
 	// Do we meet requirements to place the card
 	const canAttach = cardInfo.canAttach(game, pos)
+	player.hooks.canAttach.call(canAttach, pos)
 
 	// It's the wrong kind of slot
-	if (canAttach === 'INVALID') return 'FAILURE_INVALID_SLOT'
+	if (canAttach.includes('INVALID_PLAYER')) return 'FAILURE_INVALID_PLAYER'
+	if (canAttach.includes('INVALID_SLOT')) return 'FAILURE_INVALID_SLOT'
 	// If it's the right kind of slot, but we can't attach
-	if (canAttach === 'NO') return 'FAILURE_CANNOT_ATTACH'
+	if (canAttach.includes('UNMET_CONDITION_SILENT')) return 'FAILURE_UNMET_CONDITION_SILENT'
+	if (canAttach.includes('UNMET_CONDITION')) return 'FAILURE_UNMET_CONDITION'
 
 	// Finally, execute depending on where we tried to place
 	// And set the action result to be sent to the client

--- a/server/src/routines/turn-actions/play-card.ts
+++ b/server/src/routines/turn-actions/play-card.ts
@@ -23,7 +23,8 @@ function* playCardSaga(
 	const {playerId, rowIndex: pickedIndex, slot: pickedSlot} = pickInfo
 
 	const cardInfo = CARDS[card.cardId]
-	const {opponentPlayerId} = game
+	// opponentPlayerId is relative to where the card is being placed
+	const opponentPlayerId = playerId === currentPlayer.id ? game.opponentPlayerId : currentPlayer.id
 
 	// Card must be in hand to play it
 	if (!currentPlayer.hand.find((handCard) => equalCard(handCard, card))) {
@@ -42,10 +43,10 @@ function* playCardSaga(
 
 	// We can't automatically get the card pos, as the card is not on the board yet
 	const basicPos: BasicCardPos = {
-		player: game.state.players[playerId],
+		player,
 		opponentPlayer: game.state.players[opponentPlayerId],
 		rowIndex: pickedIndex === undefined ? null : pickedIndex,
-		row: pickedIndex !== undefined ? game.state.players[playerId].board.rows[pickedIndex] : null,
+		row: pickedIndex !== undefined ? player.board.rows[pickedIndex] : null,
 		slot: {type: pickedSlot.type, index: pickedSlot.index},
 	}
 

--- a/server/src/utils/state-gen.ts
+++ b/server/src/utils/state-gen.ts
@@ -15,7 +15,7 @@ import {PlayerModel} from 'common/models/player-model'
 import {EnergyT, SlotPos} from 'common/types/cards'
 import {AttackModel} from 'common/models/attack-model'
 import {GameHook, WaterfallHook} from 'common/types/hooks'
-import Card from 'common/cards/base/card'
+import Card, {CanAttachResult} from 'common/cards/base/card'
 import HermitCard from 'common/cards/base/hermit-card'
 import ItemCard from 'common/cards/base/item-card'
 import EffectCard from 'common/cards/base/effect-card'
@@ -223,6 +223,7 @@ export function getPlayerState(player: PlayerModel): PlayerState {
 			availableEnergy: new WaterfallHook<(availableEnergy: Array<EnergyT>) => Array<EnergyT>>(),
 			blockedActions: new WaterfallHook<(blockedActions: TurnActions) => TurnActions>(),
 
+			canAttach: new GameHook<(canAttach: CanAttachResult, pos: CardPosModel) => void>(),
 			onAttach: new GameHook<(instance: string) => void>(),
 			onDetach: new GameHook<(instance: string) => void>(),
 			beforeApply: new GameHook<() => void>(),


### PR DESCRIPTION
The canAttach method now returns an array of any problems with attaching the card.

All cards that move cards around on the board now correctly check to see if a card is ok with being moved - this means a lot less unintended behaviour.