### PR TITLE
Fix "I Needed That" checking wrong slot

### DIFF
--- a/common/achievements/double-emerald.ts
+++ b/common/achievements/double-emerald.ts
@@ -20,6 +20,7 @@ const DoubleEmerald: Achievement = {
 		},
 	],
 	onGameStart(game, player, component, observer) {
+		const {opponentPlayer} = player
 		const sentCards: Set<CardEntity> = new Set()
 
 		observer.subscribeWithPriority(
@@ -33,17 +34,24 @@ const DoubleEmerald: Achievement = {
 				)
 				if (!SUSlot) return
 				if (SUSlot.card?.props !== Emerald) return
-				const sending = player.activeRow?.getAttach()
-				if (!sending) return
-				sentCards.add(sending.entity)
+				const attachEffect = opponentPlayer.activeRow?.getAttach()
+				if (!attachEffect || sentCards.has(attachEffect.entity)) return
+				sentCards.add(attachEffect.entity)
+				observer.subscribe(
+					attachEffect.hooks.onChangeSlot,
+					(newSlot, oldSlot) => {
+						if (
+							newSlot.player.entity !== player.entity ||
+							oldSlot.player.entity !== opponentPlayer.entity ||
+							game.currentPlayerEntity !== player.entity
+						)
+							return
+
+						component.updateGoalProgress({goal: 0})
+					},
+				)
 			},
 		)
-
-		observer.subscribe(player.hooks.onAttach, (card) => {
-			if (!sentCards.has(card.entity)) return
-
-			component.updateGoalProgress({goal: 0})
-		})
 	},
 }
 

--- a/tests/unit/game/achievements/double-emerald.test.ts
+++ b/tests/unit/game/achievements/double-emerald.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, test} from '@jest/globals'
+import DoubleEmerald from 'common/achievements/double-emerald'
+import {IronArmor} from 'common/cards/attach/armor'
+import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
+import GrianRare from 'common/cards/hermits/grian-rare'
+import Emerald from 'common/cards/single-use/emerald'
+import {testAchivement} from '../utils'
+
+describe('Test I Needed That achievement', () => {
+	test('Test using two emeralds after an Attach effect', async () => {
+		await testAchivement({
+			achievement: DoubleEmerald,
+			playerOneDeck: [EthosLabCommon, Emerald, Emerald, IronArmor],
+			playerTwoDeck: [EthosLabCommon],
+			playGame: async (test, game) => {
+				await test.playCardFromHand(EthosLabCommon, 'hermit', 0)
+				await test.endTurn()
+
+				await test.playCardFromHand(EthosLabCommon, 'hermit', 0)
+				await test.endTurn()
+
+				await test.playCardFromHand(IronArmor, 'attach', 0)
+				await test.playCardFromHand(Emerald, 'single_use')
+				await test.applyEffect()
+				await test.endTurn()
+
+				await test.endTurn()
+
+				await test.playCardFromHand(Emerald, 'single_use')
+				await test.applyEffect()
+
+				await test.forfeit(game.currentPlayerEntity)
+			},
+			checkAchivement(_game, achievement, _outcome) {
+				expect(DoubleEmerald.getProgress(achievement.goals)).toBe(1)
+			},
+		})
+	})
+
+	test('Test stealing a sent Attach effect with Rare Grian', async () => {
+		await testAchivement(
+			{
+				achievement: DoubleEmerald,
+				playerOneDeck: [GrianRare, IronArmor, Emerald, Emerald],
+				playerTwoDeck: [EthosLabCommon],
+				playGame: async (test, game) => {
+					await test.playCardFromHand(GrianRare, 'hermit', 0)
+					await test.endTurn()
+
+					await test.playCardFromHand(EthosLabCommon, 'hermit', 0)
+					await test.endTurn()
+
+					await test.playCardFromHand(IronArmor, 'attach', 0)
+					await test.playCardFromHand(Emerald, 'single_use')
+					await test.applyEffect()
+					await test.attack('primary')
+					await test.finishModalRequest({result: true, cards: []}) // Attach Iron Armor to Grian
+					await test.endTurn()
+
+					await test.endTurn()
+
+					await test.playCardFromHand(Emerald, 'single_use')
+					await test.applyEffect()
+					await test.attack('primary')
+					await test.finishModalRequest({result: false, cards: null}) // Put Iron Armor in Grian's discard
+
+					await test.forfeit(game.currentPlayerEntity)
+				},
+				checkAchivement(_game, achievement, _outcome) {
+					expect(DoubleEmerald.getProgress(achievement.goals)).toBe(2)
+				},
+			},
+			{forceCoinFlip: true, noItemRequirements: true},
+		)
+	})
+})


### PR DESCRIPTION
- Fixed achievement only progressing on stealing an Attach card again after stealing it with Emerald
- Fixed achievement progressing when opponent gives back the sent Attach card.
- Added support for stealing a sent Attach card with Rare Grian and discarding it.