### PR TITLE
Fix issues with handling opponent requests

### DIFF
--- a/common/game/make-local-state.ts
+++ b/common/game/make-local-state.ts
@@ -243,9 +243,10 @@ export function getLocalGameState(
 	const currentModalRequest =
 		viewer.spectator && !viewer.replayer ? null : game.state.modalRequests[0]
 
-	if (currentModalRequest?.player === viewer.playerOnLeft.entity) {
+	if (currentModalRequest) {
 		// We must send modal requests first, to stop pick requests from overwriting them.
-		currentModalData = getLocalModalData(game, currentModalRequest.modal)
+		if (currentModalRequest?.player === viewer.playerOnLeft.entity)
+			currentModalData = getLocalModalData(game, currentModalRequest.modal)
 	} else if (currentPickRequest?.player === viewer.playerOnLeft.entity) {
 		// Once there are no modal requests, send pick requests
 		currentPickMessage = currentPickRequest.message

--- a/common/game/run-game.ts
+++ b/common/game/run-game.ts
@@ -544,12 +544,13 @@ async function turnActionsSaga(con: GameController) {
 
 		// Set final actions in state
 		let opponentAction: TurnAction = 'WAIT_FOR_TURN'
-		if (con.game.state.pickRequests[0]?.player === opponentPlayer.entity) {
-			opponentAction = 'PICK_REQUEST'
+		if (con.game.state.modalRequests[0]) {
+			if (con.game.state.modalRequests[0].player === opponentPlayer.entity)
+				opponentAction = 'MODAL_REQUEST'
 		} else if (
-			con.game.state.modalRequests[0]?.player === opponentPlayer.entity
+			con.game.state.pickRequests[0]?.player === opponentPlayer.entity
 		) {
-			opponentAction = 'MODAL_REQUEST'
+			opponentAction = 'PICK_REQUEST'
 		}
 		con.game.state.turn.opponentAvailableActions = [opponentAction]
 		con.game.state.turn.availableActions = availableActions

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -12,10 +12,10 @@ import query from 'common/components/query'
 import {CONFIG} from 'common/config'
 import {COINS} from 'common/cosmetics/coins'
 import {defaultAppearance} from 'common/cosmetics/default'
-import ExBossAI from 'common/game//virtual/exboss-ai'
 import {getLocalGameState} from 'common/game/make-local-state'
 import runGame, {getTimerForSeconds} from 'common/game/run-game'
 import {OpponentDefs} from 'common/game/setup-game'
+import ExBossAI from 'common/game/virtual/exboss-ai'
 import {PlayerId, PlayerModel} from 'common/models/player-model'
 import {
 	RecievedClientMessage,

--- a/tests/fuzz/run-game.ts
+++ b/tests/fuzz/run-game.ts
@@ -2,11 +2,11 @@ import {Card} from 'common/cards/types'
 import {AIComponent} from 'common/components/ai-component'
 import {defaultAppearance} from 'common/cosmetics/default'
 import {GameController} from 'common/game/game-controller'
+import runGame from 'common/game/run-game'
 import {PlayerSetupDefs} from 'common/game/setup-game'
 import {GameSettings} from 'common/models/game-model'
 import {CurrentCoinFlip} from 'common/types/game-state'
 import {VirtualAI} from 'common/types/virtual-ai'
-import gameSaga from 'server/routines/game'
 
 class FuzzyGameController extends GameController {
 	public override getRandomDelayForAI(_flips: Array<CurrentCoinFlip>) {
@@ -31,6 +31,7 @@ function getTestPlayer(playerName: string, deck: Array<Card>): PlayerSetupDefs {
 const defaultGameSettings = {
 	maxTurnTime: 90 * 1000,
 	extraActionTime: 30 * 1000,
+	gameTimeout: 5000,
 	showHooksState: {
 		enabled: false,
 		clearConsole: false,
@@ -50,6 +51,7 @@ const defaultGameSettings = {
 	logErrorsToStderr: false,
 	verboseLogging: !!process.env.UNIT_VERBOSE,
 	disableRewardCards: false,
+	logAttackHistory: true,
 } satisfies GameSettings
 
 /**
@@ -94,7 +96,7 @@ export async function testGame(options: {
 		options.playerTwo.AI,
 	)
 
-	await gameSaga(controller)
+	await runGame(controller)
 
 	return controller.game.outcome!
 }

--- a/tests/unit/game/hermits/evilxisuma-rare.test.ts
+++ b/tests/unit/game/hermits/evilxisuma-rare.test.ts
@@ -5,6 +5,7 @@ import EvilXisumaRare from 'common/cards/hermits/evilxisuma-rare'
 import JoeHillsRare from 'common/cards/hermits/joehills-rare'
 import ZombieCleoRare from 'common/cards/hermits/zombiecleo-rare'
 import ChorusFruit from 'common/cards/single-use/chorus-fruit'
+import Knockback from 'common/cards/single-use/knockback'
 import {StatusEffectComponent} from 'common/components'
 import query from 'common/components/query'
 import {GameModel} from 'common/models/game-model'
@@ -142,6 +143,58 @@ describe('Test Evil X', () => {
 							query.effect.targetIsCardAnd(query.card.currentPlayer),
 						),
 					).toBeTruthy()
+				},
+			},
+			{noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+	test('Test Evil X secondary disables original Hermit when used with Knockback', async () => {
+		await testGame(
+			{
+				playerOneDeck: [EthosLabCommon, EthosLabCommon],
+				playerTwoDeck: [EvilXisumaRare, Knockback],
+				testGame: async (test, game) => {
+					await test.playCardFromHand(EthosLabCommon, 'hermit', 0)
+					await test.playCardFromHand(EthosLabCommon, 'hermit', 1)
+					await test.endTurn()
+
+					await test.playCardFromHand(EvilXisumaRare, 'hermit', 0)
+					await test.playCardFromHand(Knockback, 'single_use')
+					await test.attack('secondary')
+					expect(game.state.turn.availableActions).toStrictEqual([
+						'MODAL_REQUEST',
+					])
+					expect(game.state.turn.opponentAvailableActions).toStrictEqual([
+						'WAIT_FOR_TURN',
+					])
+
+					await test.finishModalRequest({pick: 'secondary'})
+					expect(
+						game.opponentPlayer
+							.getActiveHermit()
+							?.getStatusEffect(SecondaryAttackDisabledEffect),
+					).toBeTruthy()
+					expect(game.state.turn.availableActions).toStrictEqual([
+						'WAIT_FOR_OPPONENT_ACTION',
+					])
+					expect(game.state.turn.opponentAvailableActions).toStrictEqual([
+						'PICK_REQUEST',
+					])
+
+					await test.pick(
+						query.slot.opponent,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+					expect(
+						game.opponentPlayer
+							.getActiveHermit()
+							?.getStatusEffect(SecondaryAttackDisabledEffect),
+					).toBeFalsy()
+
+					await test.endTurn()
+
+					expect(game.state.turn.availableActions).toContain('SECONDARY_ATTACK')
 				},
 			},
 			{noItemRequirements: true, forceCoinFlip: true},

--- a/tests/unit/game/hermits/ijevin-rare.test.ts
+++ b/tests/unit/game/hermits/ijevin-rare.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, test} from '@jest/globals'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import FarmerBeefCommon from 'common/cards/hermits/farmerbeef-common'
 import IJevinRare from 'common/cards/hermits/ijevin-rare'
-import {printBoardState} from 'server/utils'
+import {printBoardState} from 'common/utils/game'
 import {testGame} from '../utils'
 
 describe('Test iJevin Peace Out', () => {


### PR DESCRIPTION
- Opponent can fulfill pick requests while the current player has an active modal request.
(e.g. Changing active hermit Knockback before opponent chooses an attack to disable for Derpcoin)
- Opponent cannot fulfill modal requests if the next pick request targets the opponent