### PR TITLE
Fix early Jack of All Cards unlock

### DIFF
--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -1923,12 +1923,15 @@ export class Database {
 
 				// If we add a new level of an achievement the user may have the goal complete but will not have the achievement.
 				// This code grants the user the level for the achievement the first time they log in after said update.
+				let achievementProgress =
+					achievement.getProgress(progress[row['achievement_id']].goals) || 0
 				for (const [i, level] of achievement.levels.entries()) {
 					if (
-						row['progress'] > level.steps &&
-						progress[row['achievement_id']].levels[row['level']]
-							?.completionTime === undefined
+						achievementProgress >= level.steps &&
+						progress[row['achievement_id']].levels[i].completionTime ===
+							undefined
 					) {
+						// TODO: The database should create an entry in 'user_goals' if one does not exist for the new level
 						progress[row['achievement_id']].levels[i].completionTime = new Date(
 							Date.now(),
 						)

--- a/tests/db/database.test.ts
+++ b/tests/db/database.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@jest/globals'
 import {ACHIEVEMENTS_LIST} from 'common/achievements'
 import DefeatEvilX from 'common/achievements/defeat-evil-x'
+import AllCards from 'common/achievements/jack-of-all-cards'
 import {BalancedWins} from 'common/achievements/type-wins'
 import Win from 'common/achievements/wins'
 import {CARDS, CARDS_LIST} from 'common/cards'
@@ -712,6 +713,10 @@ describe('Test Database', () => {
 					goals: {0: 10},
 					levels: [],
 				},
+				[AllCards.numericId]: {
+					goals: {0: AllCards.levels[0].steps},
+					levels: [],
+				},
 			},
 			completionTime,
 		)
@@ -737,6 +742,10 @@ describe('Test Database', () => {
 		])
 		expect(achievements[BalancedWins.numericId].goals).toStrictEqual({0: 10})
 		expect(achievements[BalancedWins.numericId].levels).toStrictEqual([{}, {}])
+		expect(achievements[AllCards.numericId].goals).toStrictEqual({
+			0: AllCards.levels[0].steps,
+		})
+		expect(achievements[AllCards.numericId].levels).toStrictEqual([{}])
 
 		expect(
 			await database.getPlayerAchievementProgress(DefeatEvilX, player1.uuid),

--- a/tests/db/database.test.ts
+++ b/tests/db/database.test.ts
@@ -679,6 +679,21 @@ describe('Test Database', () => {
 		expect(returnedDeck3.type).toBe('success')
 	})
 
+	const ALL_CARDS_GOALS = [
+		3, 10, 2, 34, 61, 34, 19, 68, 12, 1, 23, 8, 15, 39, 10, 11, 25, 8, 3, 4, 39,
+		22, 11, 160, 6, 22, 23, 33, 17, 11, 6, 0, 9, 1, 7, 0, 9, 0, 5, 1, 3, 10, 79,
+		9, 6, 6, 0, 0, 18, 1, 40, 31, 42, 37, 56, 45, 21, 12, 15, 10, 14, 10, 56, 9,
+		36, 31, 78, 21, 0, 17, 0, 4, 21, 18, 6, 13, 27, 4, 2, 2, 10, 19, 2, 0, 50,
+		0, 7, 11, 9, 5, 3, 6, 11, 2, 29, 1, 15, 14, 6, 11, 32, 1, 9, 11, 2, 10, 7,
+		30, 1, 5, 37, 28, 1, 19, 1, 7,
+	].reduce(
+		(r, val, key) => {
+			val && (r[key] = val)
+			return r
+		},
+		{} as Record<number, number>,
+	)
+
 	test('Test achievement progress is saved', async () => {
 		const user1 = await database.insertUser('Test User')
 		const user2 = await database.insertUser('Test User 2')
@@ -714,7 +729,7 @@ describe('Test Database', () => {
 					levels: [],
 				},
 				[AllCards.numericId]: {
-					goals: {0: AllCards.levels[0].steps},
+					goals: ALL_CARDS_GOALS,
 					levels: [],
 				},
 			},
@@ -742,9 +757,9 @@ describe('Test Database', () => {
 		])
 		expect(achievements[BalancedWins.numericId].goals).toStrictEqual({0: 10})
 		expect(achievements[BalancedWins.numericId].levels).toStrictEqual([{}, {}])
-		expect(achievements[AllCards.numericId].goals).toStrictEqual({
-			0: AllCards.levels[0].steps,
-		})
+		expect(achievements[AllCards.numericId].goals).toStrictEqual(
+			ALL_CARDS_GOALS,
+		)
 		expect(achievements[AllCards.numericId].levels).toStrictEqual([{}])
 
 		expect(
@@ -786,7 +801,10 @@ describe('Test Database', () => {
 			player2.uuid,
 			{
 				// Default Evil X achievement
-				6: {goals: {0: 1}, levels: [{completionTime: completionTime}]},
+				[DefeatEvilX.numericId]: {
+					goals: {0: 1},
+					levels: [{completionTime: completionTime}],
+				},
 			},
 			completionTime,
 		)

--- a/tests/db/database.test.ts
+++ b/tests/db/database.test.ts
@@ -679,21 +679,6 @@ describe('Test Database', () => {
 		expect(returnedDeck3.type).toBe('success')
 	})
 
-	const ALL_CARDS_GOALS = [
-		3, 10, 2, 34, 61, 34, 19, 68, 12, 1, 23, 8, 15, 39, 10, 11, 25, 8, 3, 4, 39,
-		22, 11, 160, 6, 22, 23, 33, 17, 11, 6, 0, 9, 1, 7, 0, 9, 0, 5, 1, 3, 10, 79,
-		9, 6, 6, 0, 0, 18, 1, 40, 31, 42, 37, 56, 45, 21, 12, 15, 10, 14, 10, 56, 9,
-		36, 31, 78, 21, 0, 17, 0, 4, 21, 18, 6, 13, 27, 4, 2, 2, 10, 19, 2, 0, 50,
-		0, 7, 11, 9, 5, 3, 6, 11, 2, 29, 1, 15, 14, 6, 11, 32, 1, 9, 11, 2, 10, 7,
-		30, 1, 5, 37, 28, 1, 19, 1, 7,
-	].reduce(
-		(r, val, key) => {
-			val && (r[key] = val)
-			return r
-		},
-		{} as Record<number, number>,
-	)
-
 	test('Test achievement progress is saved', async () => {
 		const user1 = await database.insertUser('Test User')
 		const user2 = await database.insertUser('Test User 2')
@@ -729,7 +714,7 @@ describe('Test Database', () => {
 					levels: [],
 				},
 				[AllCards.numericId]: {
-					goals: ALL_CARDS_GOALS,
+					goals: {[BdoubleO100Common.numericId]: 200},
 					levels: [],
 				},
 			},
@@ -757,9 +742,9 @@ describe('Test Database', () => {
 		])
 		expect(achievements[BalancedWins.numericId].goals).toStrictEqual({0: 10})
 		expect(achievements[BalancedWins.numericId].levels).toStrictEqual([{}, {}])
-		expect(achievements[AllCards.numericId].goals).toStrictEqual(
-			ALL_CARDS_GOALS,
-		)
+		expect(achievements[AllCards.numericId].goals).toStrictEqual({
+			[BdoubleO100Common.numericId]: 200,
+		})
 		expect(achievements[AllCards.numericId].levels).toStrictEqual([{}])
 
 		expect(


### PR DESCRIPTION
Fixes players unlocking "Jack of All Cards" reward after winning at least 116 games with one base set card (e.g. Fishing Rod) instead of at least one game with each base set card.